### PR TITLE
perf: lineage explorer Phase 1 quick wins

### DIFF
--- a/docs/plan-lineage-performance.md
+++ b/docs/plan-lineage-performance.md
@@ -1,0 +1,119 @@
+# Plan: Lineage Explorer Performance Tuning
+
+## Context
+
+Models with many edges/references (e.g. `fact_docket` with 145 referenced-by nodes) cause the lineage explorer to slow down. The root causes are: no virtualization, expensive layout recomputation on every interaction, per-edge style object creation, and unlimited-depth highlight traversal on hover.
+
+## Current Bottlenecks (severity order)
+
+| # | Bottleneck | Location | Impact |
+|---|-----------|----------|--------|
+| 1 | Dagre layout + layer alignment | `LineageFlow.tsx` `computeLayout()` (~300 lines) | Runs on every depth/filter/direction change, O(N log N) + custom alignment |
+| 2 | No virtualization | `<ReactFlow>` renders all nodes/edges to DOM | 500+ nodes = 500+ DOM elements regardless of viewport |
+| 3 | Per-edge style objects | `rfEdges` memo creates individual `style` + `markerEnd` per edge | 500 edges = 1000+ object allocations per highlight change |
+| 4 | Unlimited highlight BFS | `getFullChain()` in `utils/graphTraversal.ts` | Traverses entire edge array with no depth cap on hover |
+| 5 | Double subgraph computation | `LineagePage.tsx` calls `getSubgraph()` twice | Once for display, once for filter option extraction |
+
+---
+
+## Phase 1: Quick Wins
+
+Low effort, medium impact. Can be done in a single session.
+
+### 1.1 Debounce highlight on hover
+
+- Add 50–100ms debounce to `setHoveredId` in `LineageFlow.tsx`
+- Prevents BFS recomputation on every pixel of mouse movement
+- Use a simple `setTimeout`/`clearTimeout` pattern (no new deps needed)
+
+### 1.2 Cap highlight depth
+
+- `getFullChain()` currently traverses the entire graph (unlimited depth)
+- Limit traversal to match the current subgraph depth (e.g. depth 2–3)
+- Add a `maxDepth` parameter to `getUpstream()`/`getDownstream()` in `graphTraversal.ts`
+
+### 1.3 Shared SVG markers for edges
+
+- Currently each edge creates its own `markerEnd` object with inline color
+- Define 2–3 shared `<marker>` SVG defs (highlighted, default, dimmed) and reference by ID
+- Eliminates ~500 object allocations for a 500-edge graph
+
+### 1.4 Memoize `getFullChain` by nodeId
+
+- Cache results in a `Map<string, Set<string>>` keyed by nodeId
+- Clear cache when edges change (new subgraph)
+- Re-hovering the same node becomes instant
+
+### 1.5 Deduplicate subgraph computation
+
+- In `LineagePage.tsx`, compute filter options from the already-computed subgraph nodes instead of calling `getSubgraph()` a second time
+- `computeSubgraphOptions()` already takes nodes — just pass `rawSubgraph.nodes` once
+
+---
+
+## Phase 2: Biggest Bang
+
+Medium effort, high impact. Core architectural improvements.
+
+### 2.1 Cap subgraph size with auto-reduce
+
+- If a given depth yields more than N nodes (e.g. 300), auto-reduce depth until under the threshold
+- Show a toast/banner: "Reduced to depth N (too many nodes at depth M)"
+- Prevents the DOM from ever rendering an unmanageable number of elements
+
+### 2.2 Move layout to a Web Worker
+
+- `computeLayout()` blocks the main thread during dagre + layer alignment
+- Move to a dedicated Web Worker:
+  - Post `{ nodes, edges, folderNodeIds }` to worker
+  - Worker runs dagre + alignment, posts back `LayoutResult`
+  - Main thread shows a lightweight skeleton/spinner during computation
+- Keeps UI responsive during layout of large graphs
+
+### 2.3 Cache layout results
+
+- Key: hash of sorted node IDs + sorted edge pairs
+- Store: `Map<string, LayoutResult>` (bounded LRU, e.g. 10 entries)
+- Toggling filters back and forth reuses cached layouts instead of recomputing
+- Combine with Web Worker — cache check happens before posting to worker
+
+### 2.4 Stable node references to reduce React reconciliation
+
+- Currently `rfNodes` creates new objects whenever `highlightedSet` changes (every hover)
+- Split into stable position data (changes only on layout) and volatile visual data (changes on hover)
+- Use React Flow's `nodeData` vs `style` separation so React doesn't diff 500 nodes on every hover
+- Ensure `DagNode`/`FolderNode` are wrapped in `React.memo` with shallow comparison
+
+---
+
+## Phase 3: Long-Term
+
+Higher effort, highest ceiling. For when the project scales to very large dbt projects.
+
+### 3.1 Server-side pre-layout
+
+- Compute dagre layout in Python during `docglow generate`
+- Ship node positions in `docglow-data.json` alongside node metadata
+- Frontend skips layout computation entirely — just renders at provided positions
+- Layout still recomputed client-side for filtered/subgraph views, but full-project view is instant
+
+### 3.2 Switch from dagre to elkjs
+
+- ELK (Eclipse Layout Kernel) is faster than dagre for large layered graphs
+- Native Web Worker support (`elkjs/lib/elk-worker.min.js`)
+- Better layered layout algorithm that may eliminate some custom post-layout alignment code
+- Breaking change to layout output format — test visually before committing
+
+### 3.3 Canvas/WebGL rendering
+
+- ReactFlow supports canvas-based rendering for large graphs
+- Alternative: switch to `react-force-graph` or `Sigma.js` for WebGL
+- DOM rendering hits a practical wall at 500–1000 nodes
+- Trade-off: lose some CSS styling flexibility, gain 10x+ node capacity
+
+### 3.4 Progressive disclosure / expand-on-demand
+
+- Start with immediate neighbors only (depth 1)
+- User clicks a node edge handle to expand one level outward from that node
+- Keeps visible node count low regardless of graph complexity
+- Requires UX design for expand/collapse affordances on nodes

--- a/frontend/src/components/lineage/LineageFlow.tsx
+++ b/frontend/src/components/lineage/LineageFlow.tsx
@@ -25,6 +25,7 @@ const NODE_WIDTH = 180
 const NODE_HEIGHT = 44
 const FOLDER_NODE_WIDTH = 220
 const FOLDER_NODE_HEIGHT = 60
+const HIGHLIGHT_DEPTH_CAP = 4
 
 const RESOURCE_COLORS: Record<string, string> = {
   model: '#2563eb',
@@ -347,7 +348,18 @@ function LineageFlowInner({
   const [hoveredId, setHoveredId] = useState<string | null>(null)
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null)
   const clickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [dragOverrides, setDragOverrides] = useState<Record<string, { x: number; y: number }>>({})
+
+  // Debounced hover setter — avoids BFS recomputation on fast mouse movement
+  const setHoveredIdDebounced = useCallback((id: string | null) => {
+    if (hoverTimerRef.current) clearTimeout(hoverTimerRef.current)
+    if (id === null) {
+      setHoveredId(null)
+      return
+    }
+    hoverTimerRef.current = setTimeout(() => setHoveredId(id), 60)
+  }, [])
 
   const centerOnHighlight = useCallback(() => {
     if (!highlightId) return
@@ -366,11 +378,24 @@ function LineageFlowInner({
     [nodes, edges, folderNodeIds],
   )
 
-  // Highlighting
+  // Highlighting — depth-capped with memoized cache
   const activeId = hoveredId ?? highlightId ?? null
+  const highlightCacheRef = useRef(new Map<string, Set<string>>())
+  const highlightCacheEdgesRef = useRef(edges)
+
+  // Clear cache when edges change
+  if (highlightCacheEdgesRef.current !== edges) {
+    highlightCacheEdgesRef.current = edges
+    highlightCacheRef.current = new Map()
+  }
+
   const highlightedSet = useMemo(() => {
     if (!activeId) return null
-    return getFullChain(activeId, edges)
+    const cached = highlightCacheRef.current.get(activeId)
+    if (cached) return cached
+    const result = getFullChain(activeId, edges, HIGHLIGHT_DEPTH_CAP)
+    highlightCacheRef.current.set(activeId, result)
+    return result
   }, [activeId, edges])
 
   // Compute layer bands from layout positions
@@ -524,6 +549,21 @@ function LineageFlowInner({
     })
   }, [])
 
+  // Shared marker definitions — avoids creating per-edge marker objects
+  const MARKER_HIGHLIGHTED = useMemo(() => ({
+    type: MarkerType.ArrowClosed as const,
+    color: '#2563eb',
+    width: 16,
+    height: 12,
+  }), [])
+
+  const MARKER_DEFAULT = useMemo(() => ({
+    type: MarkerType.ArrowClosed as const,
+    color: '#94a3b8',
+    width: 16,
+    height: 12,
+  }), [])
+
   // Build React Flow edges
   const rfEdges = useMemo((): Edge[] => {
     return layout.edges.map((e) => {
@@ -542,15 +582,10 @@ function LineageFlowInner({
           opacity: !highlightedSet ? 0.5 : isHighlighted ? 0.8 : 0.15,
           transition: 'opacity 0.15s ease, stroke 0.15s ease',
         },
-        markerEnd: {
-          type: MarkerType.ArrowClosed,
-          color: isHighlighted ? '#2563eb' : '#94a3b8',
-          width: 16,
-          height: 12,
-        },
+        markerEnd: isHighlighted ? MARKER_HIGHLIGHTED : MARKER_DEFAULT,
       }
     })
-  }, [layout.edges, highlightedSet])
+  }, [layout.edges, highlightedSet, MARKER_HIGHLIGHTED, MARKER_DEFAULT])
 
   // Fit view when data changes
   useEffect(() => {
@@ -560,12 +595,12 @@ function LineageFlowInner({
   }, [layout.nodes.length, layout.edges.length, fitView])
 
   const handleNodeMouseEnter: NodeMouseHandler = useCallback((_, node) => {
-    setHoveredId(node.id)
-  }, [])
+    setHoveredIdDebounced(node.id)
+  }, [setHoveredIdDebounced])
 
   const handleNodeMouseLeave: NodeMouseHandler = useCallback(() => {
-    setHoveredId(null)
-  }, [])
+    setHoveredIdDebounced(null)
+  }, [setHoveredIdDebounced])
 
   // Single click → open side panel; double click → navigate to detail page
   const handleNodeClick: NodeMouseHandler = useCallback((_, node) => {

--- a/frontend/src/pages/LineagePage.tsx
+++ b/frontend/src/pages/LineagePage.tsx
@@ -61,19 +61,21 @@ export function LineagePage() {
       .slice(0, 20)
   }, [data, search])
 
-  // Compute subgraph, then apply filters
-  const subgraph = useMemo(() => {
+  // Compute raw subgraph once, then derive filtered view and filter options from it
+  const rawSubgraph = useMemo(() => {
     if (!data || !selectedNodeId) return null
-    const raw = getSubgraph(selectedNodeId, data.lineage.nodes, data.lineage.edges, depth, direction)
-    return applyFilters(raw.nodes, raw.edges, typeFilter, tagFilter, folderFilter)
-  }, [data, selectedNodeId, depth, direction, typeFilter, tagFilter, folderFilter])
-
-  // Available options derived from the unfiltered subgraph
-  const subgraphOptions = useMemo(() => {
-    if (!data || !selectedNodeId) return { tags: [], folders: [], types: RESOURCE_TYPES }
-    const raw = getSubgraph(selectedNodeId, data.lineage.nodes, data.lineage.edges, depth, direction)
-    return computeSubgraphOptions(raw.nodes)
+    return getSubgraph(selectedNodeId, data.lineage.nodes, data.lineage.edges, depth, direction)
   }, [data, selectedNodeId, depth, direction])
+
+  const subgraph = useMemo(() => {
+    if (!rawSubgraph) return null
+    return applyFilters(rawSubgraph.nodes, rawSubgraph.edges, typeFilter, tagFilter, folderFilter)
+  }, [rawSubgraph, typeFilter, tagFilter, folderFilter])
+
+  const subgraphOptions = useMemo(() => {
+    if (!rawSubgraph) return { tags: [], folders: [], types: RESOURCE_TYPES }
+    return computeSubgraphOptions(rawSubgraph.nodes)
+  }, [rawSubgraph])
 
   const selectedNode = useMemo(() => {
     if (!data || !selectedNodeId) return null

--- a/frontend/src/utils/graphTraversal.ts
+++ b/frontend/src/utils/graphTraversal.ts
@@ -1,45 +1,75 @@
 import type { LineageEdge } from '../types'
 
-/** Collect all upstream node IDs (recursive BFS backward). */
-export function getUpstream(nodeId: string, edges: LineageEdge[]): Set<string> {
-  const visited = new Set<string>()
-  const queue = [nodeId]
+/** Build adjacency index for fast traversal (avoids scanning all edges per BFS step). */
+function buildAdjacency(edges: LineageEdge[]): {
+  byTarget: Map<string, string[]>
+  bySource: Map<string, string[]>
+} {
+  const byTarget = new Map<string, string[]>()
+  const bySource = new Map<string, string[]>()
+  for (const e of edges) {
+    const t = byTarget.get(e.target)
+    if (t) t.push(e.source)
+    else byTarget.set(e.target, [e.source])
+    const s = bySource.get(e.source)
+    if (s) s.push(e.target)
+    else bySource.set(e.source, [e.target])
+  }
+  return { byTarget, bySource }
+}
 
-  while (queue.length > 0) {
-    const current = queue.shift()!
-    for (const e of edges) {
-      if (e.target === current && !visited.has(e.source)) {
-        visited.add(e.source)
-        queue.push(e.source)
+/** Collect upstream node IDs via BFS. Optional maxDepth caps traversal depth. */
+export function getUpstream(nodeId: string, edges: LineageEdge[], maxDepth?: number): Set<string> {
+  const { byTarget } = buildAdjacency(edges)
+  const visited = new Set<string>()
+  let frontier = [nodeId]
+  let depth = 0
+
+  while (frontier.length > 0 && (maxDepth == null || depth < maxDepth)) {
+    const next: string[] = []
+    for (const current of frontier) {
+      for (const source of (byTarget.get(current) ?? [])) {
+        if (!visited.has(source)) {
+          visited.add(source)
+          next.push(source)
+        }
       }
     }
+    frontier = next
+    depth++
   }
 
   return visited
 }
 
-/** Collect all downstream node IDs (recursive BFS forward). */
-export function getDownstream(nodeId: string, edges: LineageEdge[]): Set<string> {
+/** Collect downstream node IDs via BFS. Optional maxDepth caps traversal depth. */
+export function getDownstream(nodeId: string, edges: LineageEdge[], maxDepth?: number): Set<string> {
+  const { bySource } = buildAdjacency(edges)
   const visited = new Set<string>()
-  const queue = [nodeId]
+  let frontier = [nodeId]
+  let depth = 0
 
-  while (queue.length > 0) {
-    const current = queue.shift()!
-    for (const e of edges) {
-      if (e.source === current && !visited.has(e.target)) {
-        visited.add(e.target)
-        queue.push(e.target)
+  while (frontier.length > 0 && (maxDepth == null || depth < maxDepth)) {
+    const next: string[] = []
+    for (const current of frontier) {
+      for (const target of (bySource.get(current) ?? [])) {
+        if (!visited.has(target)) {
+          visited.add(target)
+          next.push(target)
+        }
       }
     }
+    frontier = next
+    depth++
   }
 
   return visited
 }
 
-/** Get full dependency chain: upstream + downstream + self. */
-export function getFullChain(nodeId: string, edges: LineageEdge[]): Set<string> {
-  const upstream = getUpstream(nodeId, edges)
-  const downstream = getDownstream(nodeId, edges)
+/** Get dependency chain: upstream + downstream + self, capped to maxDepth per direction. */
+export function getFullChain(nodeId: string, edges: LineageEdge[], maxDepth?: number): Set<string> {
+  const upstream = getUpstream(nodeId, edges, maxDepth)
+  const downstream = getDownstream(nodeId, edges, maxDepth)
   return new Set([nodeId, ...upstream, ...downstream])
 }
 


### PR DESCRIPTION
## Summary
- **Debounced hover**: 60ms delay on `setHoveredId` prevents BFS recomputation during fast mouse movement
- **Capped highlight depth**: `getFullChain` now limited to 4 levels (was unlimited), preventing 1000+ node traversals on hub nodes
- **Adjacency-indexed BFS**: Rewrote `getUpstream`/`getDownstream` to use pre-built adjacency maps instead of scanning all edges per BFS step
- **Highlight cache**: Results cached per nodeId in a ref-based Map, cleared when edges change — re-hovering is instant
- **Shared edge markers**: Two stable marker objects shared across all edges instead of per-edge allocations
- **Deduplicated subgraph**: `LineagePage` now computes raw subgraph once, deriving both filtered view and filter options from it

Also adds `docs/plan-lineage-performance.md` documenting 3 phases of planned performance work.

## Test plan
- [ ] Hover rapidly over nodes in a dense graph (e.g. `fact_docket` lineage) — should feel snappier, no jank
- [ ] Hover the same node twice — second hover should be instant (cached)
- [ ] Verify highlight chain still visually traces upstream/downstream correctly
- [ ] Change depth/filters — verify highlight cache resets and new highlights work
- [ ] Open LineagePage, select a model — verify filter options still populate correctly
- [ ] Build passes: `cd frontend && npm run build`