### PR TITLE
Add CI/CD pipelines, dynamic versioning, and changelog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install ruff
+      - run: ruff check src/ tests/
+      - run: ruff format --check src/ tests/
+
+  type-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -e ".[dev]"
+      - run: mypy src/docglow
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install -e ".[dev,profiling,ai,cloud]"
+      - run: pytest --cov=docglow --cov-report=term-missing

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,21 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install build
+      - run: python -m build
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Changed
+- Version is now dynamically sourced from `src/docglow/__init__.py` (single source of truth)
+
+### Added
+- CI workflow: lint, type check, and test matrix (Python 3.10–3.13)
+- Publish workflow: automatic PyPI release via Trusted Publishers on GitHub Release
+
+## [0.1.0] - 2026-03-12
+
+### Added
+- Initial release on PyPI
+- dbt documentation site generator with React frontend
+- Interactive lineage explorer (React Flow) with drag, zoom, fullscreen, and direction toggle
+- Model detail panel with column docs, tests, and profiling stats
+- Histogram visualizations for profiled columns
+- Resizable sidebar with search and layer filtering
+- Collapsible dependency sections and node detail panel
+- Layer bands and draggable nodes in lineage view
+- Bring Your Own Key (BYOK) support for AI-powered descriptions
+- `--watch` mode for live regeneration during development
+- Profiling integration with DuckDB
+- CLI entry point (`docglow`)
+
+### Performance
+- Debounced hover and capped highlight depth in lineage explorer
+- Suppressed hover highlights during node drag to prevent flicker
+- Shared SVG markers to reduce DOM overhead
+
+[Unreleased]: https://github.com/docglow/docglow/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/docglow/docglow/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "docglow"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Next-generation dbt documentation site generator"
 readme = "README.md"
 license = "MIT"
@@ -71,6 +71,9 @@ Changelog = "https://github.com/docglow/docglow/blob/main/CHANGELOG.md"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+path = "src/docglow/__init__.py"
 
 [tool.hatch.build.targets.sdist]
 include = ["src/docglow"]


### PR DESCRIPTION
## Summary
- **Dynamic versioning**: version now sourced from `src/docglow/__init__.py` via Hatchling (eliminates duplication with `pyproject.toml`)
- **CI workflow**: ruff lint, mypy type check, pytest with coverage across Python 3.10–3.13 on every push/PR to main
- **Publish workflow**: builds and publishes to PyPI via Trusted Publishers (OIDC) when a GitHub Release is created
- **Changelog**: added `CHANGELOG.md` following Keep a Changelog format with 0.1.0 entries

## Test plan
- [ ] Verify `python -m build` still produces correct version in the artifact
- [ ] Verify CI workflow runs on this PR
- [ ] Verify publish workflow only triggers on GitHub Release (not on push)