### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-03-12
+
 ### Changed
 - Version is now dynamically sourced from `src/docglow/__init__.py` (single source of truth)
 
@@ -35,5 +37,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Suppressed hover highlights during node drag to prevent flicker
 - Shared SVG markers to reduce DOM overhead
 
-[Unreleased]: https://github.com/docglow/docglow/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/docglow/docglow/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/docglow/docglow/compare/v0.1.0...v0.2.0 
 [0.1.0]: https://github.com/docglow/docglow/releases/tag/v0.1.0

--- a/src/docglow/__init__.py
+++ b/src/docglow/__init__.py
@@ -1,3 +1,3 @@
 """docglow: Next-generation dbt documentation site generator."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"


### PR DESCRIPTION
## Summary
- Bump version to 0.2.0
- Update CHANGELOG.md with 0.2.0 release entries

## After merge
Create a GitHub Release tagged `v0.2.0` from main to trigger PyPI publish.