### PR TITLE
Fix CI: lint, type-check, and test errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,3 +98,14 @@ markers = [
 [tool.mypy]
 python_version = "3.10"
 strict = true
+
+[[tool.mypy.overrides]]
+module = [
+    "yaml",
+    "sqlalchemy",
+    "sqlalchemy.*",
+    "httpx",
+    "duckdb",
+    "duckdb_engine",
+]
+ignore_missing_imports = true

--- a/src/docglow/ai/prompts.py
+++ b/src/docglow/ai/prompts.py
@@ -2,21 +2,31 @@
 
 from __future__ import annotations
 
-SYSTEM_PROMPT = """You are an expert dbt analytics engineer assistant embedded in a documentation site. You help users understand their dbt project by answering questions about models, sources, lineage, tests, and data quality.
-
-You have access to the full project metadata below. Use it to answer questions accurately.
-
-Guidelines:
-- Be concise and direct
-- When referencing models, use their exact names
-- When asked about dependencies, trace the lineage graph from the metadata
-- When asked "what would break", list all downstream models that depend on the mentioned model
-- When asked about data quality, reference test results and health scores
-- If you're unsure about something, say so rather than guessing
-- Format model and source names in backticks for clarity
-
-Project metadata:
-{context}"""
+SYSTEM_PROMPT = (
+    "You are an expert dbt analytics engineer assistant embedded"
+    " in a documentation site. You help users understand their"
+    " dbt project by answering questions about models, sources,"
+    " lineage, tests, and data quality.\n"
+    "\n"
+    "You have access to the full project metadata below."
+    " Use it to answer questions accurately.\n"
+    "\n"
+    "Guidelines:\n"
+    "- Be concise and direct\n"
+    "- When referencing models, use their exact names\n"
+    "- When asked about dependencies, trace the lineage graph"
+    " from the metadata\n"
+    '- When asked "what would break", list all downstream'
+    " models that depend on the mentioned model\n"
+    "- When asked about data quality, reference test results"
+    " and health scores\n"
+    "- If you're unsure about something, say so rather than"
+    " guessing\n"
+    "- Format model and source names in backticks for clarity\n"
+    "\n"
+    "Project metadata:\n"
+    "{context}"
+)
 
 
 STARTER_QUESTIONS = [

--- a/src/docglow/analyzer/complexity.py
+++ b/src/docglow/analyzer/complexity.py
@@ -88,20 +88,22 @@ def analyze_complexity(
         if is_high:
             high_count += 1
 
-        results.append(ModelComplexity(
-            unique_id=uid,
-            name=model.get("name", ""),
-            folder=model.get("folder", ""),
-            sql_lines=sql_lines,
-            join_count=join_count,
-            cte_count=cte_count,
-            subquery_count=subquery_count,
-            downstream_count=downstream_count,
-            is_high_complexity=is_high,
-        ))
+        results.append(
+            ModelComplexity(
+                unique_id=uid,
+                name=model.get("name", ""),
+                folder=model.get("folder", ""),
+                sql_lines=sql_lines,
+                join_count=join_count,
+                cte_count=cte_count,
+                subquery_count=subquery_count,
+                downstream_count=downstream_count,
+                is_high_complexity=is_high,
+            )
+        )
 
     # Sort by complexity indicators (most complex first)
-    results.sort(key=lambda m: (m.sql_lines + m.join_count * 10 + m.cte_count * 5), reverse=True)
+    results.sort(key=lambda m: m.sql_lines + m.join_count * 10 + m.cte_count * 5, reverse=True)
 
     return ComplexityReport(
         models=results,

--- a/src/docglow/analyzer/coverage.py
+++ b/src/docglow/analyzer/coverage.py
@@ -65,22 +65,26 @@ def compute_coverage(
             models_with_desc += 1
             folder_documented[folder] = folder_documented.get(folder, 0) + 1
         else:
-            undocumented.append({
-                "unique_id": uid,
-                "name": model.get("name", ""),
-                "folder": folder,
-                "downstream_count": downstream_count,
-            })
+            undocumented.append(
+                {
+                    "unique_id": uid,
+                    "name": model.get("name", ""),
+                    "folder": folder,
+                    "downstream_count": downstream_count,
+                }
+            )
 
         if has_tests:
             models_with_tests += 1
         else:
-            untested.append({
-                "unique_id": uid,
-                "name": model.get("name", ""),
-                "folder": folder,
-                "downstream_count": downstream_count,
-            })
+            untested.append(
+                {
+                    "unique_id": uid,
+                    "name": model.get("name", ""),
+                    "folder": folder,
+                    "downstream_count": downstream_count,
+                }
+            )
 
         for col in model.get("columns", []):
             total_columns += 1

--- a/src/docglow/analyzer/health.py
+++ b/src/docglow/analyzer/health.py
@@ -48,15 +48,13 @@ def _compute_freshness_score(
     sources: dict[str, dict[str, Any]],
 ) -> float:
     """Compute freshness score from source freshness data."""
-    monitored = [
-        s for s in sources.values()
-        if s.get("freshness_status") is not None
-    ]
+    monitored = [s for s in sources.values() if s.get("freshness_status") is not None]
     if not monitored:
         return 100.0  # No monitored sources = not applicable, full score
 
     passing = sum(
-        1 for s in monitored
+        1
+        for s in monitored
         if s.get("freshness_status") in ("pass", "runtime error")
         # "runtime error" means freshness was checked but source had issues,
         # still counts as "monitored"
@@ -78,11 +76,13 @@ def _find_orphans(
     for uid, model in all_models.items():
         referenced_by = model.get("referenced_by", [])
         if len(referenced_by) == 0:
-            orphans.append({
-                "unique_id": uid,
-                "name": model.get("name", ""),
-                "folder": model.get("folder", ""),
-            })
+            orphans.append(
+                {
+                    "unique_id": uid,
+                    "name": model.get("name", ""),
+                    "folder": model.get("folder", ""),
+                }
+            )
 
     return orphans
 
@@ -104,22 +104,16 @@ def compute_health(
     coverage = compute_coverage(models, sources, seeds, snapshots)
 
     # Documentation score: avg of model + column coverage
-    doc_score = (
-        (coverage.models_documented.rate + coverage.columns_documented.rate) / 2
-    ) * 100.0
+    doc_score = ((coverage.models_documented.rate + coverage.columns_documented.rate) / 2) * 100.0
 
     # Test score: avg of model + column test coverage
-    test_score = (
-        (coverage.models_tested.rate + coverage.columns_tested.rate) / 2
-    ) * 100.0
+    test_score = ((coverage.models_tested.rate + coverage.columns_tested.rate) / 2) * 100.0
 
     # Freshness score
     freshness_score = _compute_freshness_score(sources)
 
     # Complexity analysis
-    complexity = analyze_complexity(
-        models, seeds, snapshots, config.complexity
-    )
+    complexity = analyze_complexity(models, seeds, snapshots, config.complexity)
     complexity_score = complexity.compliance_rate * 100.0
 
     # Naming analysis

--- a/src/docglow/analyzer/naming.py
+++ b/src/docglow/analyzer/naming.py
@@ -68,34 +68,40 @@ def check_naming(
 
         if layer == "staging":
             if not re.match(rules.staging, name):
-                violations.append(NamingViolation(
-                    unique_id=uid,
-                    name=name,
-                    folder=folder,
-                    expected_pattern=rules.staging,
-                    layer=layer,
-                ))
+                violations.append(
+                    NamingViolation(
+                        unique_id=uid,
+                        name=name,
+                        folder=folder,
+                        expected_pattern=rules.staging,
+                        layer=layer,
+                    )
+                )
         elif layer == "intermediate":
             if not re.match(rules.intermediate, name):
-                violations.append(NamingViolation(
-                    unique_id=uid,
-                    name=name,
-                    folder=folder,
-                    expected_pattern=rules.intermediate,
-                    layer=layer,
-                ))
+                violations.append(
+                    NamingViolation(
+                        unique_id=uid,
+                        name=name,
+                        folder=folder,
+                        expected_pattern=rules.intermediate,
+                        layer=layer,
+                    )
+                )
         elif layer == "marts":
             # Marts models should start with fct_ or dim_
             matches_fact = re.match(rules.marts_fact, name)
             matches_dim = re.match(rules.marts_dimension, name)
             if not matches_fact and not matches_dim:
-                violations.append(NamingViolation(
-                    unique_id=uid,
-                    name=name,
-                    folder=folder,
-                    expected_pattern=f"{rules.marts_fact} or {rules.marts_dimension}",
-                    layer=layer,
-                ))
+                violations.append(
+                    NamingViolation(
+                        unique_id=uid,
+                        name=name,
+                        folder=folder,
+                        expected_pattern=f"{rules.marts_fact} or {rules.marts_dimension}",
+                        layer=layer,
+                    )
+                )
 
     compliant = total_checked - len(violations)
     return NamingReport(

--- a/src/docglow/artifacts/catalog.py
+++ b/src/docglow/artifacts/catalog.py
@@ -43,7 +43,7 @@ class CatalogNode(BaseModel):
     """A node (table/view) in the dbt catalog."""
 
     unique_id: str
-    metadata: CatalogNodeMetadata = Field(default_factory=CatalogNodeMetadata)
+    metadata: CatalogNodeMetadata = Field(default_factory=CatalogNodeMetadata)  # type: ignore[arg-type]
     columns: dict[str, CatalogColumnInfo] = Field(default_factory=dict)
     stats: dict[str, CatalogStat] = Field(default_factory=dict)
 

--- a/src/docglow/artifacts/loader.py
+++ b/src/docglow/artifacts/loader.py
@@ -6,6 +6,7 @@ import json
 import logging
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from docglow.artifacts.catalog import Catalog
 from docglow.artifacts.manifest import Manifest
@@ -38,7 +39,7 @@ def _resolve_target_dir(project_dir: Path, target_dir: Path | None) -> Path:
     return project_dir / "target"
 
 
-def _load_json(path: Path) -> dict:
+def _load_json(path: Path) -> dict[str, Any]:
     """Load and parse a JSON file with clear error messages."""
     if not path.exists():
         raise ArtifactLoadError(f"File not found: {path}")
@@ -61,7 +62,7 @@ def _load_json(path: Path) -> dict:
     return data
 
 
-def _load_optional_json(path: Path, artifact_name: str) -> dict | None:
+def _load_optional_json(path: Path, artifact_name: str) -> dict[str, Any] | None:
     """Load an optional artifact, returning None with a warning if missing."""
     if not path.exists():
         logger.warning("%s not found at %s — skipping", artifact_name, path)
@@ -94,8 +95,7 @@ def load_artifacts(
 
     if not resolved_target.exists():
         raise ArtifactLoadError(
-            f"Target directory not found: {resolved_target}. "
-            "Have you run 'dbt docs generate'?"
+            f"Target directory not found: {resolved_target}. Have you run 'dbt docs generate'?"
         )
 
     # Required artifacts
@@ -109,9 +109,7 @@ def load_artifacts(
     _log_artifact_info("catalog.json", catalog.metadata.dbt_schema_version)
 
     # Optional artifacts
-    run_results_data = _load_optional_json(
-        resolved_target / "run_results.json", "run_results.json"
-    )
+    run_results_data = _load_optional_json(resolved_target / "run_results.json", "run_results.json")
     run_results = (
         RunResults.model_validate(run_results_data) if run_results_data is not None else None
     )
@@ -143,12 +141,8 @@ def _log_summary(
     source_freshness: SourceFreshness | None,
 ) -> None:
     """Log a summary of loaded artifacts."""
-    model_count = sum(
-        1 for n in manifest.nodes.values() if n.resource_type == "model"
-    )
-    test_count = sum(
-        1 for n in manifest.nodes.values() if n.resource_type == "test"
-    )
+    model_count = sum(1 for n in manifest.nodes.values() if n.resource_type == "model")
+    test_count = sum(1 for n in manifest.nodes.values() if n.resource_type == "test")
     source_count = len(manifest.sources)
     catalog_node_count = len(catalog.nodes) + len(catalog.sources)
     result_count = len(run_results.results) if run_results else 0

--- a/src/docglow/artifacts/manifest.py
+++ b/src/docglow/artifacts/manifest.py
@@ -66,7 +66,7 @@ class ManifestNode(BaseModel):
     columns: dict[str, ManifestColumnInfo] = Field(default_factory=dict)
     meta: dict[str, object] = Field(default_factory=dict)
     tags: list[str] = Field(default_factory=list)
-    config: NodeConfig = Field(default_factory=NodeConfig)
+    config: NodeConfig = Field(default_factory=NodeConfig)  # type: ignore[arg-type]
     depends_on: DependsOn = Field(default_factory=DependsOn)
     raw_code: str = Field("", alias="raw_code")
     compiled_code: str | None = Field(None, alias="compiled_code")

--- a/src/docglow/cli.py
+++ b/src/docglow/cli.py
@@ -32,7 +32,11 @@ def cli() -> None:
 @click.option("--target-dir", type=click.Path(path_type=Path), default=None)
 @click.option("--output-dir", type=click.Path(path_type=Path), default=None)
 @click.option("--profile/--no-profile", default=False, help="Enable column profiling")
-@click.option("--profile-adapter", type=click.Choice(["duckdb", "postgres", "snowflake"]), default=None)
+@click.option(
+    "--profile-adapter",
+    type=click.Choice(["duckdb", "postgres", "snowflake"]),
+    default=None,
+)
 @click.option("--profile-connection", type=str, default=None, help="Connection string or DB path")
 @click.option("--profile-sample-size", type=int, default=None)
 @click.option("--profile-no-cache", is_flag=True, help="Skip profile caching")
@@ -40,7 +44,12 @@ def cli() -> None:
 @click.option("--exclude", type=str, default=None, help="Exclude matching models")
 @click.option("--static", is_flag=True, help="Bundle everything into single index.html")
 @click.option("--ai", is_flag=True, help="Enable AI chat panel")
-@click.option("--ai-key", type=str, default=None, help="Anthropic API key (or set ANTHROPIC_API_KEY env var)")
+@click.option(
+    "--ai-key",
+    type=str,
+    default=None,
+    help="Anthropic API key (or set ANTHROPIC_API_KEY env var)",
+)
 @click.option("--title", type=str, default=None, help="Custom site title")
 @click.option("--theme", type=click.Choice(["light", "dark", "auto"]), default="auto")
 @click.option("--verbose", is_flag=True)
@@ -122,7 +131,14 @@ def generate(
 @click.option("--dir", "serve_dir", type=click.Path(path_type=Path), default=None)
 @click.option("--watch", is_flag=True, help="Watch for artifact changes and auto-rebuild")
 @click.option("--project-dir", type=click.Path(exists=True, path_type=Path), default=".")
-def serve(port: int, host: str, open: bool, serve_dir: Path | None, watch: bool, project_dir: Path) -> None:
+def serve(
+    port: int,
+    host: str,
+    open: bool,
+    serve_dir: Path | None,
+    watch: bool,
+    project_dir: Path,
+) -> None:
     """Serve the documentation site locally."""
     from docglow.server.dev import start_server
 
@@ -136,6 +152,7 @@ def serve(port: int, host: str, open: bool, serve_dir: Path | None, watch: bool,
 
     if watch:
         from docglow.server.watcher import start_watcher
+
         start_watcher(project_dir, resolved_dir, console)
 
     start_server(resolved_dir, host=host, port=port, open_browser=open)
@@ -144,7 +161,12 @@ def serve(port: int, host: str, open: bool, serve_dir: Path | None, watch: bool,
 @cli.command()
 @click.option("--project-dir", type=click.Path(exists=True, path_type=Path), default=".")
 @click.option("--target-dir", type=click.Path(path_type=Path), default=None)
-@click.option("--format", "output_format", type=click.Choice(["table", "json", "markdown"]), default="table")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["table", "json", "markdown"]),
+    default="table",
+)
 @click.option("--select", type=str, default=None)
 def health(
     project_dir: Path,
@@ -157,7 +179,6 @@ def health(
 
     from rich.table import Table
 
-    from docglow.analyzer.health import compute_health, health_to_dict
     from docglow.artifacts.loader import ArtifactLoadError, load_artifacts
     from docglow.generator.data import build_docglow_data
 
@@ -178,12 +199,17 @@ def health(
 
     # Table or markdown output
     grade_color = {
-        "A": "green", "B": "blue", "C": "yellow", "D": "red", "F": "bold red",
+        "A": "green",
+        "B": "blue",
+        "C": "yellow",
+        "D": "red",
+        "F": "bold red",
     }.get(score["grade"], "white")
 
     console.print()
-    console.print(f"[bold]docglow Project Health[/bold]")
-    console.print(f"  Overall Score: [{grade_color}]{score['overall']:.0f}/100 ({score['grade']})[/{grade_color}]")
+    console.print("[bold]docglow Project Health[/bold]")
+    overall = f"{score['overall']:.0f}/100 ({score['grade']})"
+    console.print(f"  Overall Score: [{grade_color}]{overall}[/{grade_color}]")
     console.print()
 
     table = Table(show_header=True, header_style="bold")
@@ -207,7 +233,7 @@ def health(
     table.add_row(
         "Source Freshness",
         f"{score['freshness']:.0f}",
-        "No monitored sources" if score['freshness'] == 100.0 else "",
+        "No monitored sources" if score["freshness"] == 100.0 else "",
     )
     table.add_row(
         "Model Complexity",
@@ -217,7 +243,8 @@ def health(
     table.add_row(
         "Naming Conventions",
         f"{score['naming']:.0f}",
-        f"{health_data['naming']['compliant_count']}/{health_data['naming']['total_checked']} compliant",
+        f"{health_data['naming']['compliant_count']}"
+        f"/{health_data['naming']['total_checked']} compliant",
     )
     table.add_row(
         "Orphan Detection",
@@ -233,10 +260,20 @@ def health(
 @click.option("--project-dir", type=click.Path(exists=True, path_type=Path), default=".")
 @click.option("--target-dir", type=click.Path(path_type=Path), default=None)
 @click.option("--adapter", type=click.Choice(["duckdb", "postgres", "snowflake"]), required=True)
-@click.option("--connection", type=str, required=True, help="Connection string or path (e.g., path/to/db.duckdb)")
+@click.option(
+    "--connection",
+    type=str,
+    required=True,
+    help="Connection string or path (e.g., path/to/db.duckdb)",
+)
 @click.option("--sample-size", type=int, default=None, help="Max rows to sample per model")
 @click.option("--no-cache", is_flag=True, help="Skip profile caching")
-@click.option("--output", type=click.Path(path_type=Path), default=None, help="Output directory for profiles.json")
+@click.option(
+    "--output",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Output directory for profiles.json",
+)
 @click.option("--verbose", is_flag=True)
 def profile(
     project_dir: Path,
@@ -255,7 +292,7 @@ def profile(
 
     from docglow.artifacts.loader import ArtifactLoadError, load_artifacts
     from docglow.generator.data import build_docglow_data
-    from docglow.profiler.engine import ProfilerError, apply_profiles, profile_models
+    from docglow.profiler.engine import ProfilerError, profile_models
 
     try:
         artifacts = load_artifacts(project_dir, target_dir)
@@ -296,7 +333,12 @@ def profile(
 
 
 @cli.command()
-@click.option("--token", envvar="DOCGLOW_TOKEN", default=None, help="API token (or set DOCGLOW_TOKEN env var)")
+@click.option(
+    "--token",
+    envvar="DOCGLOW_TOKEN",
+    default=None,
+    help="API token (or set DOCGLOW_TOKEN env var)",
+)
 @click.option("--project-dir", type=click.Path(exists=True, path_type=Path), default=".")
 @click.option("--target-dir", type=click.Path(path_type=Path), default=None)
 @click.option("--no-wait", is_flag=True, help="Don't wait for processing to complete")
@@ -324,6 +366,7 @@ def publish(
     config = load_cloud_config()
     if token:
         from dataclasses import replace
+
         config = replace(config, token=token)
 
     if not config.token:
@@ -335,20 +378,21 @@ def publish(
 
     try:
         from docglow.cloud.client import CloudApiError
+
         result = run_publish(config, project_dir, target_dir, no_wait=no_wait)
         status = result.get("status", "unknown")
 
         if status == "complete":
             site_url = result.get("site_url", "")
             health_score = result.get("health_score")
-            console.print(f"\n[bold green]Published successfully![/bold green]")
+            console.print("\n[bold green]Published successfully![/bold green]")
             if site_url:
                 console.print(f"  Site: {site_url}")
             if health_score is not None:
                 console.print(f"  Health score: {health_score}")
         else:
             publish_id = result.get("publish_id", "")
-            console.print(f"\n[bold blue]Upload complete[/bold blue]")
+            console.print("\n[bold blue]Upload complete[/bold blue]")
             console.print(f"  Publish ID: {publish_id}")
             console.print(f"  Status: {status}")
     except FileNotFoundError as e:
@@ -395,6 +439,7 @@ def status(token: str | None, verbose: bool) -> None:
     config = load_cloud_config()
     if token:
         from dataclasses import replace
+
         config = replace(config, token=token)
 
     if not config.token:
@@ -451,7 +496,7 @@ def setup() -> None:
 
     save_cloud_config(workspace_slug=workspace, project_slug=project)
     console.print("\n[bold green]Setup complete![/bold green]")
-    console.print(f"  Config saved to ~/.docglow/config.json")
+    console.print("  Config saved to ~/.docglow/config.json")
 
 
 def _parse_connection(adapter: str, connection: str) -> dict[str, str]:

--- a/src/docglow/cloud/client.py
+++ b/src/docglow/cloud/client.py
@@ -27,8 +27,7 @@ class CloudClient:
             import httpx
         except ImportError as e:
             raise ImportError(
-                "httpx is required for cloud features. "
-                "Install it with: pip install docglow[cloud]"
+                "httpx is required for cloud features. Install it with: pip install docglow[cloud]"
             ) from e
 
         self._config = config
@@ -62,7 +61,8 @@ class CloudClient:
                 status_code=response.status_code,
             )
 
-        return response.json()
+        result: dict[str, Any] = response.json()
+        return result
 
     def get_publish_status(self, publish_id: str) -> dict[str, Any]:
         """Check the status of a publish operation."""
@@ -74,7 +74,8 @@ class CloudClient:
                 status_code=response.status_code,
             )
 
-        return response.json()
+        result: dict[str, Any] = response.json()
+        return result
 
     def get_workspace_info(self) -> dict[str, Any]:
         """Get workspace information and status."""
@@ -86,7 +87,8 @@ class CloudClient:
                 status_code=response.status_code,
             )
 
-        return response.json()
+        result: dict[str, Any] = response.json()
+        return result
 
     def close(self) -> None:
         """Close the HTTP client."""

--- a/src/docglow/config.py
+++ b/src/docglow/config.py
@@ -115,34 +115,63 @@ def _build_config_from_dict(raw: dict[str, Any]) -> DocglowConfig:
     ai_raw = raw.get("ai", {})
     lineage_raw = raw.get("lineage_layers", {})
 
-    weights = HealthWeights(
-        **{k: v for k, v in health_raw.get("weights", {}).items()
-           if k in HealthWeights.__dataclass_fields__}
-    ) if health_raw.get("weights") else HealthWeights()
+    weights = (
+        HealthWeights(
+            **{
+                k: v
+                for k, v in health_raw.get("weights", {}).items()
+                if k in HealthWeights.__dataclass_fields__
+            }
+        )
+        if health_raw.get("weights")
+        else HealthWeights()
+    )
 
-    naming_rules = NamingRules(
-        **{k: v for k, v in health_raw.get("naming_rules", {}).items()
-           if k in NamingRules.__dataclass_fields__}
-    ) if health_raw.get("naming_rules") else NamingRules()
+    naming_rules = (
+        NamingRules(
+            **{
+                k: v
+                for k, v in health_raw.get("naming_rules", {}).items()
+                if k in NamingRules.__dataclass_fields__
+            }
+        )
+        if health_raw.get("naming_rules")
+        else NamingRules()
+    )
 
-    complexity = ComplexityThresholds(
-        **{k: v for k, v in health_raw.get("complexity", {}).items()
-           if k in ComplexityThresholds.__dataclass_fields__}
-    ) if health_raw.get("complexity") else ComplexityThresholds()
+    complexity = (
+        ComplexityThresholds(
+            **{
+                k: v
+                for k, v in health_raw.get("complexity", {}).items()
+                if k in ComplexityThresholds.__dataclass_fields__
+            }
+        )
+        if health_raw.get("complexity")
+        else ComplexityThresholds()
+    )
 
-    profiling = ProfilingConfig(
-        enabled=profiling_raw.get("enabled", False),
-        sample_size=profiling_raw.get("sample_size", 10000),
-        cache=profiling_raw.get("cache", True),
-        exclude_schemas=tuple(profiling_raw.get("exclude_schemas", ())),
-        top_values_threshold=profiling_raw.get("top_values_threshold", 50),
-    ) if profiling_raw else ProfilingConfig()
+    profiling = (
+        ProfilingConfig(
+            enabled=profiling_raw.get("enabled", False),
+            sample_size=profiling_raw.get("sample_size", 10000),
+            cache=profiling_raw.get("cache", True),
+            exclude_schemas=tuple(profiling_raw.get("exclude_schemas", ())),
+            top_values_threshold=profiling_raw.get("top_values_threshold", 50),
+        )
+        if profiling_raw
+        else ProfilingConfig()
+    )
 
-    ai = AiConfig(
-        enabled=ai_raw.get("enabled", False),
-        model=ai_raw.get("model", "claude-sonnet-4-20250514"),
-        max_requests_per_session=ai_raw.get("max_requests_per_session", 20),
-    ) if ai_raw else AiConfig()
+    ai = (
+        AiConfig(
+            enabled=ai_raw.get("enabled", False),
+            model=ai_raw.get("model", "claude-sonnet-4-20250514"),
+            max_requests_per_session=ai_raw.get("max_requests_per_session", 20),
+        )
+        if ai_raw
+        else AiConfig()
+    )
 
     lineage_layers = parse_layer_config(lineage_raw) if lineage_raw else LineageLayerConfig()
 

--- a/src/docglow/generator/bundle.py
+++ b/src/docglow/generator/bundle.py
@@ -29,8 +29,7 @@ def _find_frontend_dist() -> Path:
         return dev_dist
 
     raise FileNotFoundError(
-        "Built frontend assets not found. "
-        "Run 'npm run build' in the frontend/ directory first."
+        "Built frontend assets not found. Run 'npm run build' in the frontend/ directory first."
     )
 
 
@@ -91,7 +90,7 @@ def _bundle_static(
     html = index_path.read_text(encoding="utf-8")
 
     data_json = json.dumps(docglow_data, separators=(",", ":"))
-    data_script = f'<script>window.__DOCGLOW_DATA__={data_json};</script>'
+    data_script = f"<script>window.__DOCGLOW_DATA__={data_json};</script>"
 
     # Inject data script before closing </head> tag
     html = html.replace("</head>", f"{data_script}\n</head>")

--- a/src/docglow/generator/data.py
+++ b/src/docglow/generator/data.py
@@ -13,7 +13,7 @@ from docglow.artifacts.catalog import Catalog, CatalogColumnInfo
 from docglow.artifacts.loader import LoadedArtifacts
 from docglow.artifacts.manifest import Manifest, ManifestNode, ManifestSource
 from docglow.artifacts.run_results import RunResult, RunResults
-from docglow.generator.layers import LineageLayerConfig, resolve_all_layers, layers_to_dict
+from docglow.generator.layers import LineageLayerConfig, layers_to_dict, resolve_all_layers
 
 
 @dataclass(frozen=True)
@@ -208,15 +208,17 @@ def build_docglow_data(
     # Apply --select / --exclude filtering
     if select or exclude:
         models, seeds, snapshots = _filter_resources(
-            models, seeds, snapshots, select=select, exclude=exclude,
+            models,
+            seeds,
+            snapshots,
+            select=select,
+            exclude=exclude,
         )
 
     # Transform sources
     sources: dict[str, Any] = {}
     for unique_id, source in manifest.sources.items():
-        sources[unique_id] = _transform_source(
-            source, catalog, artifacts.source_freshness
-        )
+        sources[unique_id] = _transform_source(source, catalog, artifacts.source_freshness)
 
     # Transform exposures
     exposures: dict[str, Any] = {}
@@ -246,7 +248,11 @@ def build_docglow_data(
 
     # Build lineage graph
     lineage = _build_lineage(
-        manifest, models, sources, seeds, snapshots,
+        manifest,
+        models,
+        sources,
+        seeds,
+        snapshots,
         layer_config=layer_config or LineageLayerConfig(),
     )
 
@@ -261,10 +267,17 @@ def build_docglow_data(
     ai_context: dict[str, Any] | None = None
     if ai_enabled:
         from docglow.ai.context import build_ai_context
-        ai_context = build_ai_context(models, sources, seeds, metadata={
-            "project_name": manifest.metadata.project_name or "",
-            "dbt_version": manifest.metadata.dbt_version,
-        }, health=health)
+
+        ai_context = build_ai_context(
+            models,
+            sources,
+            seeds,
+            metadata={
+                "project_name": manifest.metadata.project_name or "",
+                "dbt_version": manifest.metadata.dbt_version,
+            },
+            health=health,
+        )
 
     # Metadata
     metadata = {
@@ -277,9 +290,7 @@ def build_docglow_data(
         "artifact_versions": {
             "manifest": manifest.metadata.dbt_schema_version,
             "catalog": catalog.metadata.dbt_schema_version,
-            "run_results": (
-                run_results.metadata.dbt_schema_version if run_results else None
-            ),
+            "run_results": (run_results.metadata.dbt_schema_version if run_results else None),
             "sources": None,
         },
         "profiling_enabled": profiling_enabled,
@@ -401,7 +412,12 @@ def _resolve_selection(
         folder = data.get("folder", "")
         path = data.get("path", "")
 
-        if fnmatch.fnmatch(name, clean) or fnmatch.fnmatch(folder, clean) or fnmatch.fnmatch(path, clean):
+        matches_filter = (
+            fnmatch.fnmatch(name, clean)
+            or fnmatch.fnmatch(folder, clean)
+            or fnmatch.fnmatch(path, clean)
+        )
+        if matches_filter:
             matched.add(uid)
 
     if include_upstream:
@@ -420,7 +436,9 @@ def _resolve_selection(
 
 
 def _collect_upstream(
-    uid: str, resources: dict[str, Any], visited: set[str],
+    uid: str,
+    resources: dict[str, Any],
+    visited: set[str],
 ) -> None:
     """Recursively collect upstream dependencies."""
     data = resources.get(uid)
@@ -433,7 +451,9 @@ def _collect_upstream(
 
 
 def _collect_downstream(
-    uid: str, resources: dict[str, Any], visited: set[str],
+    uid: str,
+    resources: dict[str, Any],
+    visited: set[str],
 ) -> None:
     """Recursively collect downstream dependents."""
     data = resources.get(uid)
@@ -465,9 +485,7 @@ def _transform_model(
     columns = _merge_columns(node, catalog_node, run_results_by_id, test_nodes_by_model)
 
     # Build test results for this model
-    test_results = _build_test_results(
-        node.unique_id, test_nodes_by_model, run_results_by_id
-    )
+    test_results = _build_test_results(node.unique_id, test_nodes_by_model, run_results_by_id)
 
     # Model run result
     model_result = run_results_by_id.get(node.unique_id)
@@ -491,27 +509,27 @@ def _transform_model(
         row_count_entry = catalog_node.stats.get("row_count")
         if row_count_entry and row_count_entry.value is not None:
             try:
-                catalog_stats["row_count"] = int(row_count_entry.value)  # type: ignore[arg-type]
+                catalog_stats["row_count"] = int(row_count_entry.value)  # type: ignore[call-overload]
             except (ValueError, TypeError):
                 pass
         bytes_entry = catalog_node.stats.get("bytes")
         if bytes_entry and bytes_entry.value is not None:
             try:
-                catalog_stats["bytes"] = int(bytes_entry.value)  # type: ignore[arg-type]
+                catalog_stats["bytes"] = int(bytes_entry.value)  # type: ignore[call-overload]
             except (ValueError, TypeError):
                 pass
 
     # Extract source refs
     sources_used = [
-        f"source.{node.package_name}.{s[0]}.{s[1]}" if isinstance(s, (list, tuple)) and len(s) >= 2
+        f"source.{node.package_name}.{s[0]}.{s[1]}"
+        if isinstance(s, (list, tuple)) and len(s) >= 2
         else str(s)
         for s in node.sources
     ]
 
     # Filter reverse deps to exclude tests
     referenced_by = [
-        ref for ref in reverse_deps.get(node.unique_id, [])
-        if not ref.startswith("test.")
+        ref for ref in reverse_deps.get(node.unique_id, []) if not ref.startswith("test.")
     ]
 
     return {
@@ -528,9 +546,7 @@ def _transform_model(
         "raw_sql": node.raw_code,
         "compiled_sql": node.compiled_code or "",
         "columns": columns,
-        "depends_on": [
-            d for d in node.depends_on.nodes if not d.startswith("test.")
-        ],
+        "depends_on": [d for d in node.depends_on.nodes if not d.startswith("test.")],
         "referenced_by": referenced_by,
         "sources_used": sources_used,
         "test_results": test_results,
@@ -573,24 +589,24 @@ def _merge_columns(
             seen.add(col_name.lower())
 
     # Build column tests map
-    column_tests = _build_column_tests(
-        node.unique_id, test_nodes_by_model, run_results_by_id
-    )
+    column_tests = _build_column_tests(node.unique_id, test_nodes_by_model, run_results_by_id)
 
     columns: list[dict[str, Any]] = []
     for col_name in all_column_names:
         catalog_col = catalog_columns.get(col_name) or catalog_columns.get(col_name.lower())
         manifest_col = manifest_columns.get(col_name) or manifest_columns.get(col_name.lower())
 
-        columns.append({
-            "name": col_name,
-            "description": manifest_col.description if manifest_col else "",
-            "data_type": catalog_col.type if catalog_col else "",
-            "meta": dict(manifest_col.meta) if manifest_col else {},
-            "tags": list(manifest_col.tags) if manifest_col else [],
-            "tests": column_tests.get(col_name.lower(), []),
-            "profile": None,
-        })
+        columns.append(
+            {
+                "name": col_name,
+                "description": manifest_col.description if manifest_col else "",
+                "data_type": catalog_col.type if catalog_col else "",
+                "meta": dict(manifest_col.meta) if manifest_col else {},
+                "tags": list(manifest_col.tags) if manifest_col else [],
+                "tests": column_tests.get(col_name.lower(), []),
+                "profile": None,
+            }
+        )
 
     return columns
 
@@ -660,15 +676,17 @@ def _build_test_results(
             failures = run_result.failures or 0
             message = run_result.message
 
-        results.append({
-            "test_name": test_node.name,
-            "test_type": test_type,
-            "column_name": test_node.column_name,
-            "status": status,
-            "execution_time": execution_time,
-            "failures": failures,
-            "message": message,
-        })
+        results.append(
+            {
+                "test_name": test_node.name,
+                "test_type": test_type,
+                "column_name": test_node.column_name,
+                "status": status,
+                "execution_time": execution_time,
+                "failures": failures,
+                "message": message,
+            }
+        )
 
     return results
 
@@ -709,15 +727,17 @@ def _transform_source(
         lower_name = col.name.lower()
         if lower_name not in seen:
             manifest_col = source.columns.get(col.name) or source.columns.get(col.name.lower())
-            columns.append({
-                "name": col.name,
-                "description": manifest_col.description if manifest_col else "",
-                "data_type": col.type if hasattr(col, "type") else "",
-                "meta": dict(manifest_col.meta) if manifest_col else {},
-                "tags": list(manifest_col.tags) if manifest_col else [],
-                "tests": [],
-                "profile": None,
-            })
+            columns.append(
+                {
+                    "name": col.name,
+                    "description": manifest_col.description if manifest_col else "",
+                    "data_type": col.type if hasattr(col, "type") else "",
+                    "meta": dict(manifest_col.meta) if manifest_col else {},
+                    "tags": list(manifest_col.tags) if manifest_col else [],
+                    "tests": [],
+                    "profile": None,
+                }
+            )
             seen.add(lower_name)
 
     # Freshness info
@@ -780,18 +800,20 @@ def _build_lineage(
         if unique_id in seen_node_ids:
             return
         seen_node_ids.add(unique_id)
-        nodes.append({
-            "id": unique_id,
-            "name": name,
-            "resource_type": resource_type,
-            "materialization": materialization,
-            "schema": schema,
-            "test_status": test_status,
-            "has_description": has_description,
-            "folder": folder,
-            "tags": tags,
-            "meta": meta or {},
-        })
+        nodes.append(
+            {
+                "id": unique_id,
+                "name": name,
+                "resource_type": resource_type,
+                "materialization": materialization,
+                "schema": schema,
+                "test_status": test_status,
+                "has_description": has_description,
+                "folder": folder,
+                "tags": tags,
+                "meta": meta or {},
+            }
+        )
 
     def _get_test_status(model_data: dict[str, Any]) -> str:
         test_results = model_data.get("test_results", [])
@@ -893,14 +915,16 @@ def _build_search_index(
             column_names = [c["name"] for c in data.get("columns", [])]
             sql = data.get("compiled_sql", "") or data.get("raw_sql", "")
 
-            entries.append({
-                "unique_id": uid,
-                "name": data.get("name", ""),
-                "resource_type": resource_type,
-                "description": data.get("description", ""),
-                "columns": ", ".join(column_names),
-                "tags": ", ".join(data.get("tags", [])),
-                "sql_snippet": sql[:500],
-            })
+            entries.append(
+                {
+                    "unique_id": uid,
+                    "name": data.get("name", ""),
+                    "resource_type": resource_type,
+                    "description": data.get("description", ""),
+                    "columns": ", ".join(column_names),
+                    "tags": ", ".join(data.get("tags", [])),
+                    "sql_snippet": sql[:500],
+                }
+            )
 
     return entries

--- a/src/docglow/generator/layers.py
+++ b/src/docglow/generator/layers.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import fnmatch
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -87,12 +87,12 @@ def parse_layer_config(raw: dict[str, Any]) -> LineageLayerConfig:
     if layers_raw is not None:
         layers = tuple(
             LayerDefinition(
-                name=l["name"],
-                rank=l["rank"],
-                color=l.get("color", "#e2e8f0"),
+                name=layer["name"],
+                rank=layer["rank"],
+                color=layer.get("color", "#e2e8f0"),
             )
-            for l in layers_raw
-            if isinstance(l, dict) and "name" in l and "rank" in l
+            for layer in layers_raw
+            if isinstance(layer, dict) and "name" in layer and "rank" in layer
         )
 
     rules = DEFAULT_RULES
@@ -175,7 +175,7 @@ def resolve_node_layer(
     if resource_type in ("source", "seed"):
         return _layer_name_to_rank("source", config.layers) or 0
     if resource_type == "exposure":
-        max_rank = max((l.rank for l in config.layers), default=4)
+        max_rank = max((layer.rank for layer in config.layers), default=4)
         return max_rank
 
     return None
@@ -254,7 +254,7 @@ def resolve_all_layers(
 
     # Fallback: any still-unresolved nodes get the middle rank
     if unresolved:
-        all_ranks = [l.rank for l in config.layers]
+        all_ranks = [layer.rank for layer in config.layers]
         middle = all_ranks[len(all_ranks) // 2] if all_ranks else 2
         for node_id in unresolved:
             result[node_id] = middle
@@ -265,6 +265,5 @@ def resolve_all_layers(
 def layers_to_dict(config: LineageLayerConfig) -> list[dict[str, Any]]:
     """Convert layer definitions to a JSON-serializable list."""
     return [
-        {"name": l.name, "rank": l.rank, "color": l.color}
-        for l in config.layers
+        {"name": layer.name, "rank": layer.rank, "color": layer.color} for layer in config.layers
     ]

--- a/src/docglow/profiler/cache.py
+++ b/src/docglow/profiler/cache.py
@@ -31,7 +31,8 @@ def load_cache(cache_dir: Path) -> dict[str, Any]:
     if not cache_path.exists():
         return {}
     try:
-        return json.loads(cache_path.read_text())
+        result: dict[str, Any] = json.loads(cache_path.read_text())
+        return result
     except (json.JSONDecodeError, OSError) as e:
         logger.warning("Failed to load profile cache: %s", e)
         return {}
@@ -55,7 +56,8 @@ def is_cached(
     if entry is None:
         return False
     current_hash = _schema_hash(columns, row_count)
-    return entry.get("schema_hash") == current_hash
+    matches: bool = entry.get("schema_hash") == current_hash
+    return matches
 
 
 def get_cached_profiles(
@@ -66,7 +68,8 @@ def get_cached_profiles(
     entry = cache.get(model_id)
     if entry is None:
         return None
-    return entry.get("profiles")
+    profiles: dict[str, dict[str, Any]] | None = entry.get("profiles")
+    return profiles
 
 
 def update_cache(

--- a/src/docglow/profiler/engine.py
+++ b/src/docglow/profiler/engine.py
@@ -50,10 +50,7 @@ def _get_connection_url(adapter: str, connection_params: dict[str, Any]) -> str:
         password = connection_params.get("password", "")
         database = connection_params.get("database", "")
         warehouse = connection_params.get("warehouse", "")
-        return (
-            f"snowflake://{user}:{password}@{account}/{database}"
-            f"?warehouse={warehouse}"
-        )
+        return f"snowflake://{user}:{password}@{account}/{database}?warehouse={warehouse}"
     raise ProfilerError(f"Unsupported adapter: {adapter}")
 
 
@@ -85,8 +82,7 @@ def profile_models(
         from sqlalchemy import create_engine, text
     except ImportError as e:
         raise ProfilerError(
-            "SQLAlchemy is required for profiling. "
-            "Install with: pip install docglow[profiling]"
+            "SQLAlchemy is required for profiling. Install with: pip install docglow[profiling]"
         ) from e
 
     cache: dict[str, Any] = {}
@@ -132,12 +128,20 @@ def profile_models(
 
                 # Build and execute stats query
                 stats_sql = build_stats_query(
-                    schema, table_name, column_specs,
-                    adapter=adapter, sample_size=sample_size,
+                    schema,
+                    table_name,
+                    column_specs,
+                    adapter=adapter,
+                    sample_size=sample_size,
                 )
 
                 try:
-                    logger.debug("Profiling %s.%s (%d columns)", schema, table_name, len(column_specs))
+                    logger.debug(
+                        "Profiling %s.%s (%d columns)",
+                        schema,
+                        table_name,
+                        len(column_specs),
+                    )
                     result = conn.execute(text(stats_sql))
                     row = result.mappings().fetchone()
                     if row is None:
@@ -150,9 +154,15 @@ def profile_models(
                     for col_spec in column_specs:
                         col_profile = profiles.get(col_spec.name, {})
                         distinct = col_profile.get("distinct_count", 0)
-                        if 0 < distinct <= top_values_threshold and col_spec.category in ("string", "numeric", "boolean"):
+                        has_low_cardinality = (
+                            0 < distinct <= top_values_threshold
+                            and col_spec.category in ("string", "numeric", "boolean")
+                        )
+                        if has_low_cardinality:
                             tv_sql = build_top_values_query(
-                                schema, table_name, col_spec.name,
+                                schema,
+                                table_name,
+                                col_spec.name,
                                 adapter=adapter,
                             )
                             try:
@@ -160,7 +170,12 @@ def profile_models(
                                 tv_rows = [dict(r) for r in tv_result.mappings()]
                                 col_profile["top_values"] = parse_top_values_rows(tv_rows)
                             except Exception as e:
-                                logger.debug("Top values query failed for %s.%s: %s", table_name, col_spec.name, e)
+                                logger.debug(
+                                    "Top values query failed for %s.%s: %s",
+                                    table_name,
+                                    col_spec.name,
+                                    e,
+                                )
 
                         # Fetch histogram for numeric columns
                         if col_spec.category == "numeric":
@@ -168,17 +183,26 @@ def profile_models(
                             col_max = col_profile.get("max")
                             if col_min is not None and col_max is not None and col_max > col_min:
                                 hist_sql = build_histogram_query(
-                                    schema, table_name, col_spec.name,
+                                    schema,
+                                    table_name,
+                                    col_spec.name,
                                     adapter=adapter,
                                 )
                                 try:
                                     hist_result = conn.execute(text(hist_sql))
                                     hist_rows = [dict(r) for r in hist_result.mappings()]
                                     col_profile["histogram"] = parse_histogram_rows(
-                                        hist_rows, float(col_min), float(col_max),
+                                        hist_rows,
+                                        float(col_min),
+                                        float(col_max),
                                     )
                                 except Exception as e:
-                                    logger.debug("Histogram query failed for %s.%s: %s", table_name, col_spec.name, e)
+                                    logger.debug(
+                                        "Histogram query failed for %s.%s: %s",
+                                        table_name,
+                                        col_spec.name,
+                                        e,
+                                    )
 
                     all_profiles[model_id] = profiles
                     profiled_count += 1
@@ -200,7 +224,9 @@ def profile_models(
 
     logger.info(
         "Profiling complete: %d profiled, %d cached, %d total",
-        profiled_count, cached_count, profiled_count + cached_count,
+        profiled_count,
+        cached_count,
+        profiled_count + cached_count,
     )
     return all_profiles
 
@@ -221,8 +247,7 @@ def apply_profiles(
             continue
 
         new_columns = [
-            {**col, "profile": model_profiles.get(col["name"])}
-            for col in model.get("columns", [])
+            {**col, "profile": model_profiles.get(col["name"])} for col in model.get("columns", [])
         ]
         result[model_id] = {**model, "columns": new_columns}
 

--- a/src/docglow/profiler/queries.py
+++ b/src/docglow/profiler/queries.py
@@ -20,19 +20,50 @@ def classify_column(data_type: str) -> str:
         return "other"
 
     numeric_types = {
-        "INTEGER", "INT", "BIGINT", "SMALLINT", "TINYINT",
-        "FLOAT", "DOUBLE", "DECIMAL", "NUMBER", "NUMERIC", "REAL",
-        "INT2", "INT4", "INT8", "FLOAT4", "FLOAT8",
-        "HUGEINT", "UBIGINT", "UINTEGER", "USMALLINT", "UTINYINT",
+        "INTEGER",
+        "INT",
+        "BIGINT",
+        "SMALLINT",
+        "TINYINT",
+        "FLOAT",
+        "DOUBLE",
+        "DECIMAL",
+        "NUMBER",
+        "NUMERIC",
+        "REAL",
+        "INT2",
+        "INT4",
+        "INT8",
+        "FLOAT4",
+        "FLOAT8",
+        "HUGEINT",
+        "UBIGINT",
+        "UINTEGER",
+        "USMALLINT",
+        "UTINYINT",
     }
     date_types = {
-        "DATE", "TIMESTAMP", "DATETIME", "TIMESTAMPTZ",
-        "TIMESTAMP_NTZ", "TIMESTAMP_TZ", "TIMESTAMP_LTZ",
-        "TIMESTAMP WITH TIME ZONE", "TIMESTAMP WITHOUT TIME ZONE",
+        "DATE",
+        "TIMESTAMP",
+        "DATETIME",
+        "TIMESTAMPTZ",
+        "TIMESTAMP_NTZ",
+        "TIMESTAMP_TZ",
+        "TIMESTAMP_LTZ",
+        "TIMESTAMP WITH TIME ZONE",
+        "TIMESTAMP WITHOUT TIME ZONE",
     }
     string_types = {
-        "VARCHAR", "TEXT", "STRING", "CHAR", "CHARACTER VARYING",
-        "NVARCHAR", "NCHAR", "CLOB", "BPCHAR", "NAME",
+        "VARCHAR",
+        "TEXT",
+        "STRING",
+        "CHAR",
+        "CHARACTER VARYING",
+        "NVARCHAR",
+        "NCHAR",
+        "CLOB",
+        "BPCHAR",
+        "NAME",
     }
     boolean_types = {"BOOLEAN", "BOOL"}
 
@@ -102,29 +133,28 @@ def build_stats_query(
         parts.append(f'  , COUNT(DISTINCT {cn}) AS {prefix}__distinct_count"')
 
         if col.category == "numeric":
-            parts.append(f"  , MIN({cn}) AS {prefix}__min\"")
-            parts.append(f"  , MAX({cn}) AS {prefix}__max\"")
-            parts.append(f"  , AVG({cn})::DOUBLE AS {prefix}__mean\"")
+            parts.append(f'  , MIN({cn}) AS {prefix}__min"')
+            parts.append(f'  , MAX({cn}) AS {prefix}__max"')
+            parts.append(f'  , AVG({cn})::DOUBLE AS {prefix}__mean"')
             if adapter == "duckdb":
-                parts.append(f"  , MEDIAN({cn}::DOUBLE) AS {prefix}__median\"")
+                parts.append(f'  , MEDIAN({cn}::DOUBLE) AS {prefix}__median"')
             elif adapter == "snowflake":
-                parts.append(f"  , MEDIAN({cn}) AS {prefix}__median\"")
+                parts.append(f'  , MEDIAN({cn}) AS {prefix}__median"')
             else:
                 # PostgreSQL: use percentile_cont
                 parts.append(
-                    f"  , PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY {cn}) "
-                    f'AS {prefix}__median"'
+                    f'  , PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY {cn}) AS {prefix}__median"'
                 )
-            parts.append(f"  , STDDEV({cn})::DOUBLE AS {prefix}__stddev\"")
+            parts.append(f'  , STDDEV({cn})::DOUBLE AS {prefix}__stddev"')
 
         elif col.category == "date":
-            parts.append(f"  , MIN({cn})::VARCHAR AS {prefix}__min\"")
-            parts.append(f"  , MAX({cn})::VARCHAR AS {prefix}__max\"")
+            parts.append(f'  , MIN({cn})::VARCHAR AS {prefix}__min"')
+            parts.append(f'  , MAX({cn})::VARCHAR AS {prefix}__max"')
 
         elif col.category == "string":
-            parts.append(f"  , MIN(LENGTH({cn})) AS {prefix}__min_length\"")
-            parts.append(f"  , MAX(LENGTH({cn})) AS {prefix}__max_length\"")
-            parts.append(f"  , AVG(LENGTH({cn}))::DOUBLE AS {prefix}__avg_length\"")
+            parts.append(f'  , MIN(LENGTH({cn})) AS {prefix}__min_length"')
+            parts.append(f'  , MAX(LENGTH({cn})) AS {prefix}__max_length"')
+            parts.append(f'  , AVG(LENGTH({cn}))::DOUBLE AS {prefix}__avg_length"')
 
     # FROM clause
     table_ref = f'"{schema}"."{table_name}"' if schema else f'"{table_name}"'
@@ -163,7 +193,9 @@ def build_histogram_query(
             f"  SELECT MIN({cn})::DOUBLE AS mn, MAX({cn})::DOUBLE AS mx\n"
             f"  FROM {table_ref} WHERE {cn} IS NOT NULL\n"
             f"), binned AS (\n"
-            f"  SELECT WIDTH_BUCKET({cn}::DOUBLE, bounds.mn, bounds.mx + 1e-9, {num_bins}) AS bucket\n"
+            f"  SELECT WIDTH_BUCKET("
+            f"{cn}::DOUBLE, bounds.mn, bounds.mx + 1e-9, "
+            f"{num_bins}) AS bucket\n"
             f"  FROM {table_ref}, bounds\n"
             f"  WHERE {cn} IS NOT NULL\n"
             f")\n"
@@ -176,7 +208,9 @@ def build_histogram_query(
         f"  SELECT MIN({cn})::DOUBLE PRECISION AS mn, MAX({cn})::DOUBLE PRECISION AS mx\n"
         f"  FROM {table_ref} WHERE {cn} IS NOT NULL\n"
         f"), binned AS (\n"
-        f"  SELECT WIDTH_BUCKET({cn}::DOUBLE PRECISION, bounds.mn, bounds.mx + 1e-9, {num_bins}) AS bucket\n"
+        f"  SELECT WIDTH_BUCKET("
+        f"{cn}::DOUBLE PRECISION, bounds.mn, bounds.mx + 1e-9, "
+        f"{num_bins}) AS bucket\n"
         f"  FROM {table_ref}, bounds\n"
         f"  WHERE {cn} IS NOT NULL\n"
         f")\n"

--- a/src/docglow/profiler/stats.py
+++ b/src/docglow/profiler/stats.py
@@ -85,8 +85,7 @@ def parse_top_values_rows(
 ) -> list[dict[str, Any]]:
     """Parse top values query results into a list of {value, frequency} dicts."""
     return [
-        {"value": str(r.get("value", "")), "frequency": int(r.get("frequency", 0))}
-        for r in rows
+        {"value": str(r.get("value", "")), "frequency": int(r.get("frequency", 0))} for r in rows
     ]
 
 

--- a/src/docglow/server/watcher.py
+++ b/src/docglow/server/watcher.py
@@ -58,10 +58,7 @@ def _watch_loop(project_dir: Path, output_dir: Path, console: Any) -> None:
         current_mtimes = _get_mtimes(project_dir)
 
         if current_mtimes != last_mtimes:
-            changed = [
-                p for p in current_mtimes
-                if current_mtimes.get(p) != last_mtimes.get(p)
-            ]
+            changed = [p for p in current_mtimes if current_mtimes.get(p) != last_mtimes.get(p)]
             names = [Path(p).name for p in changed]
             console.print(f"[yellow]Detected changes in: {', '.join(names)}[/yellow]")
             _rebuild(project_dir, output_dir, console)

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -1,7 +1,5 @@
 """Tests for AI context builder."""
 
-import pytest
-
 from docglow.ai.context import build_ai_context
 
 
@@ -20,8 +18,15 @@ def _make_model(name, **overrides):
         "raw_sql": "SELECT 1",
         "compiled_sql": "SELECT 1",
         "columns": [
-            {"name": "id", "description": "Primary key", "data_type": "integer",
-             "meta": {}, "tags": [], "tests": [], "profile": None},
+            {
+                "name": "id",
+                "description": "Primary key",
+                "data_type": "integer",
+                "meta": {},
+                "tags": [],
+                "tests": [],
+                "profile": None,
+            },
         ],
         "depends_on": [],
         "referenced_by": [],
@@ -43,8 +48,15 @@ def _make_source(name, source_name="raw", **overrides):
         "schema": "raw",
         "database": "db",
         "columns": [
-            {"name": "id", "description": "", "data_type": "integer",
-             "meta": {}, "tags": [], "tests": [], "profile": None},
+            {
+                "name": "id",
+                "description": "",
+                "data_type": "integer",
+                "meta": {},
+                "tags": [],
+                "tests": [],
+                "profile": None,
+            },
         ],
         "tags": [],
         "meta": {},
@@ -185,9 +197,7 @@ class TestBuildAiContext:
         assert "row_count" not in ctx["models"][0]
 
     def test_source_fields(self):
-        sources = {
-            "s1": _make_source("raw_orders", source_name="raw_db", freshness_status="pass")
-        }
+        sources = {"s1": _make_source("raw_orders", source_name="raw_db", freshness_status="pass")}
 
         ctx = build_ai_context({}, sources, {}, METADATA, HEALTH)
         s = ctx["sources"][0]

--- a/tests/test_byok.py
+++ b/tests/test_byok.py
@@ -4,11 +4,8 @@ import os
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
-
 from docglow.artifacts.loader import load_artifacts
 from docglow.generator.data import build_docglow_data
-
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,13 +1,10 @@
 """Tests for configuration loading."""
 
-import pytest
-
 from docglow.config import (
     DocglowConfig,
     HealthWeights,
-    NamingRules,
-    load_config,
     _build_config_from_dict,
+    load_config,
 )
 
 
@@ -45,78 +42,92 @@ class TestBuildConfigFromDict:
         assert config.health.weights == HealthWeights()
 
     def test_custom_health_weights(self):
-        config = _build_config_from_dict({
-            "health": {
-                "weights": {"documentation": 0.40, "testing": 0.30},
-            },
-        })
+        config = _build_config_from_dict(
+            {
+                "health": {
+                    "weights": {"documentation": 0.40, "testing": 0.30},
+                },
+            }
+        )
         assert config.health.weights.documentation == 0.40
         assert config.health.weights.testing == 0.30
         # Unchanged defaults
         assert config.health.weights.freshness == 0.15
 
     def test_custom_naming_rules(self):
-        config = _build_config_from_dict({
-            "health": {
-                "naming_rules": {"staging": "^staging_"},
-            },
-        })
+        config = _build_config_from_dict(
+            {
+                "health": {
+                    "naming_rules": {"staging": "^staging_"},
+                },
+            }
+        )
         assert config.health.naming_rules.staging == "^staging_"
         assert config.health.naming_rules.marts_fact == "^fct_"
 
     def test_custom_complexity_thresholds(self):
-        config = _build_config_from_dict({
-            "health": {
-                "complexity": {"high_sql_lines": 300, "high_join_count": 12},
-            },
-        })
+        config = _build_config_from_dict(
+            {
+                "health": {
+                    "complexity": {"high_sql_lines": 300, "high_join_count": 12},
+                },
+            }
+        )
         assert config.health.complexity.high_sql_lines == 300
         assert config.health.complexity.high_join_count == 12
         assert config.health.complexity.high_cte_count == 10
 
     def test_profiling_config(self):
-        config = _build_config_from_dict({
-            "profiling": {
-                "enabled": True,
-                "sample_size": 5000,
-                "exclude_schemas": ["raw", "scratch"],
-            },
-        })
+        config = _build_config_from_dict(
+            {
+                "profiling": {
+                    "enabled": True,
+                    "sample_size": 5000,
+                    "exclude_schemas": ["raw", "scratch"],
+                },
+            }
+        )
         assert config.profiling.enabled is True
         assert config.profiling.sample_size == 5000
         assert config.profiling.exclude_schemas == ("raw", "scratch")
 
     def test_ai_config(self):
-        config = _build_config_from_dict({
-            "ai": {
-                "enabled": True,
-                "max_requests_per_session": 50,
-            },
-        })
+        config = _build_config_from_dict(
+            {
+                "ai": {
+                    "enabled": True,
+                    "max_requests_per_session": 50,
+                },
+            }
+        )
         assert config.ai.enabled is True
         assert config.ai.max_requests_per_session == 50
 
     def test_unknown_keys_ignored(self):
-        config = _build_config_from_dict({
-            "title": "My Docs",
-            "unknown_key": "whatever",
-            "health": {"weights": {"unknown_weight": 0.5}},
-        })
+        config = _build_config_from_dict(
+            {
+                "title": "My Docs",
+                "unknown_key": "whatever",
+                "health": {"weights": {"unknown_weight": 0.5}},
+            }
+        )
         assert config.title == "My Docs"
 
     def test_full_config(self):
-        config = _build_config_from_dict({
-            "version": 1,
-            "title": "Acme Analytics",
-            "theme": "dark",
-            "health": {
-                "weights": {"documentation": 0.30, "testing": 0.20},
-                "naming_rules": {"staging": "^stg_"},
-                "complexity": {"high_sql_lines": 150},
-            },
-            "profiling": {"enabled": True, "sample_size": 1000},
-            "ai": {"enabled": True},
-        })
+        config = _build_config_from_dict(
+            {
+                "version": 1,
+                "title": "Acme Analytics",
+                "theme": "dark",
+                "health": {
+                    "weights": {"documentation": 0.30, "testing": 0.20},
+                    "naming_rules": {"staging": "^stg_"},
+                    "complexity": {"high_sql_lines": 150},
+                },
+                "profiling": {"enabled": True, "sample_size": 1000},
+                "ai": {"enabled": True},
+            }
+        )
         assert config.title == "Acme Analytics"
         assert config.theme == "dark"
         assert config.health.weights.documentation == 0.30

--- a/tests/test_data_transformer.py
+++ b/tests/test_data_transformer.py
@@ -2,11 +2,9 @@
 
 from pathlib import Path
 
-import pytest
-
+from docglow import __version__
 from docglow.artifacts.loader import load_artifacts
 from docglow.generator.data import build_docglow_data
-
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
@@ -31,9 +29,18 @@ class TestBuildDocglowData:
         data = _load_fixtures(tmp_path)
 
         expected_keys = {
-            "metadata", "models", "sources", "seeds", "snapshots",
-            "exposures", "metrics", "lineage", "health", "search_index",
-            "ai_context", "ai_key",
+            "metadata",
+            "models",
+            "sources",
+            "seeds",
+            "snapshots",
+            "exposures",
+            "metrics",
+            "lineage",
+            "health",
+            "search_index",
+            "ai_context",
+            "ai_key",
         }
         assert set(data.keys()) == expected_keys
 
@@ -43,7 +50,7 @@ class TestBuildDocglowData:
 
         assert meta["project_name"] == "jaffle_shop"
         assert meta["dbt_version"] != ""
-        assert meta["docglow_version"] == "0.1.0"
+        assert meta["docglow_version"] == __version__
         assert meta["profiling_enabled"] is False
         assert meta["ai_enabled"] is False
         assert "manifest" in meta["artifact_versions"]
@@ -62,10 +69,24 @@ class TestBuildDocglowData:
         orders = data["models"]["model.jaffle_shop.orders"]
 
         required_fields = [
-            "unique_id", "name", "description", "schema", "database",
-            "materialization", "tags", "meta", "path", "folder",
-            "raw_sql", "compiled_sql", "columns", "depends_on",
-            "referenced_by", "sources_used", "test_results", "last_run",
+            "unique_id",
+            "name",
+            "description",
+            "schema",
+            "database",
+            "materialization",
+            "tags",
+            "meta",
+            "path",
+            "folder",
+            "raw_sql",
+            "compiled_sql",
+            "columns",
+            "depends_on",
+            "referenced_by",
+            "sources_used",
+            "test_results",
+            "last_run",
             "catalog_stats",
         ]
         for field in required_fields:
@@ -220,7 +241,7 @@ class TestBuildDocglowData:
         for model_data in data["models"].values():
             for result in model_data["test_results"]:
                 assert result["status"] != "success", (
-                    f"Test status 'success' should be normalized to 'pass'"
+                    "Test status 'success' should be normalized to 'pass'"
                 )
 
     def test_no_test_nodes_in_models(self, tmp_path: Path) -> None:

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -3,13 +3,10 @@
 import json
 from pathlib import Path
 
-import pytest
-
 from docglow.artifacts.loader import load_artifacts
 from docglow.generator.bundle import bundle_site
 from docglow.generator.data import build_docglow_data
 from docglow.generator.site import generate_site
-
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -2,8 +2,6 @@
 
 from typing import Any
 
-import pytest
-
 from docglow.analyzer.complexity import analyze_complexity
 from docglow.analyzer.coverage import compute_coverage
 from docglow.analyzer.health import compute_health, health_to_dict
@@ -136,7 +134,8 @@ class TestComplexity:
         assert result.models[0].join_count == 0
 
     def test_complex_sql(self) -> None:
-        sql = "\n".join([f"-- line {i}" for i in range(250)]) + "\nSELECT * FROM a JOIN b JOIN c JOIN d JOIN e JOIN f JOIN g JOIN h JOIN i JOIN j"
+        joins = " JOIN ".join("abcdefghij")
+        sql = "\n".join([f"-- line {i}" for i in range(250)]) + f"\nSELECT * FROM {joins}"
         models = {"m1": _make_model(compiled_sql=sql)}
         result = analyze_complexity(models, {}, {}, ComplexityThresholds(high_sql_lines=200))
         assert result.high_complexity_count == 1
@@ -218,11 +217,14 @@ class TestHealthScore:
     def test_poor_health(self) -> None:
         models = {
             "m1": _make_model(
-                name="orders", folder="models/staging",
+                name="orders",
+                folder="models/staging",
                 columns=[{"name": "id", "description": "", "tests": []}],
             ),
             "m2": _make_model(
-                uid="m2", name="revenue", folder="models/marts",
+                uid="m2",
+                name="revenue",
+                folder="models/marts",
                 columns=[{"name": "id", "description": "", "tests": []}],
             ),
         }

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -6,7 +6,6 @@ import pytest
 
 from docglow.artifacts.loader import ArtifactLoadError, LoadedArtifacts, load_artifacts
 
-
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 
@@ -53,9 +52,7 @@ class TestLoadArtifacts:
 
         result = load_artifacts(tmp_path)
 
-        models = {
-            k: v for k, v in result.manifest.nodes.items() if v.resource_type == "model"
-        }
+        models = {k: v for k, v in result.manifest.nodes.items() if v.resource_type == "model"}
         assert len(models) > 0
 
         # Check a known model
@@ -91,15 +88,12 @@ class TestLoadArtifacts:
 
         result = load_artifacts(tmp_path)
 
-        tests = {
-            k: v for k, v in result.manifest.nodes.items() if v.resource_type == "test"
-        }
+        tests = {k: v for k, v in result.manifest.nodes.items() if v.resource_type == "test"}
         assert len(tests) > 0
 
         # Find a not_null test
         not_null_tests = [
-            t for t in tests.values()
-            if t.test_metadata and t.test_metadata.name == "not_null"
+            t for t in tests.values() if t.test_metadata and t.test_metadata.name == "not_null"
         ]
         assert len(not_null_tests) > 0
         assert not_null_tests[0].column_name is not None
@@ -160,9 +154,7 @@ class TestLoadArtifacts:
         assert len(result.run_results.results) > 0
 
         # Check a test result
-        test_results = [
-            r for r in result.run_results.results if "test." in r.unique_id
-        ]
+        test_results = [r for r in result.run_results.results if "test." in r.unique_id]
         assert len(test_results) > 0
         assert test_results[0].status in ("success", "fail", "error", "warn", "pass")
 

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -2,11 +2,8 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from typing import Any
-
-import pytest
 
 from docglow.profiler.cache import (
     is_cached,

--- a/tests/test_profiler_histogram.py
+++ b/tests/test_profiler_histogram.py
@@ -1,7 +1,5 @@
 """Tests for histogram query building and parsing."""
 
-import pytest
-
 from docglow.profiler.queries import build_histogram_query
 from docglow.profiler.stats import parse_histogram_rows
 

--- a/tests/test_profiler_integration.py
+++ b/tests/test_profiler_integration.py
@@ -72,10 +72,12 @@ def _make_model(
 class TestProfilerIntegration:
     def test_profile_numeric_columns(self, duckdb_path: str) -> None:
         models = {
-            "model.test.orders": _make_model(columns=[
-                {"name": "order_id", "data_type": "INTEGER"},
-                {"name": "amount", "data_type": "DECIMAL(10,2)"},
-            ]),
+            "model.test.orders": _make_model(
+                columns=[
+                    {"name": "order_id", "data_type": "INTEGER"},
+                    {"name": "amount", "data_type": "DECIMAL(10,2)"},
+                ]
+            ),
         }
 
         profiles = profile_models(
@@ -102,9 +104,11 @@ class TestProfilerIntegration:
 
     def test_profile_string_columns(self, duckdb_path: str) -> None:
         models = {
-            "model.test.orders": _make_model(columns=[
-                {"name": "status", "data_type": "VARCHAR"},
-            ]),
+            "model.test.orders": _make_model(
+                columns=[
+                    {"name": "status", "data_type": "VARCHAR"},
+                ]
+            ),
         }
 
         profiles = profile_models(
@@ -124,9 +128,11 @@ class TestProfilerIntegration:
 
     def test_profile_date_columns(self, duckdb_path: str) -> None:
         models = {
-            "model.test.orders": _make_model(columns=[
-                {"name": "order_date", "data_type": "DATE"},
-            ]),
+            "model.test.orders": _make_model(
+                columns=[
+                    {"name": "order_date", "data_type": "DATE"},
+                ]
+            ),
         }
 
         profiles = profile_models(
@@ -143,9 +149,11 @@ class TestProfilerIntegration:
 
     def test_profile_with_cache(self, duckdb_path: str, tmp_path: Path) -> None:
         models = {
-            "model.test.orders": _make_model(columns=[
-                {"name": "order_id", "data_type": "INTEGER"},
-            ]),
+            "model.test.orders": _make_model(
+                columns=[
+                    {"name": "order_id", "data_type": "INTEGER"},
+                ]
+            ),
         }
         cache_dir = tmp_path / "cache"
         cache_dir.mkdir()
@@ -172,10 +180,12 @@ class TestProfilerIntegration:
 
     def test_apply_profiles(self, duckdb_path: str) -> None:
         models = {
-            "model.test.orders": _make_model(columns=[
-                {"name": "order_id", "data_type": "INTEGER", "profile": None},
-                {"name": "status", "data_type": "VARCHAR", "profile": None},
-            ]),
+            "model.test.orders": _make_model(
+                columns=[
+                    {"name": "order_id", "data_type": "INTEGER", "profile": None},
+                    {"name": "status", "data_type": "VARCHAR", "profile": None},
+                ]
+            ),
         }
 
         profiles = profile_models(
@@ -217,14 +227,16 @@ class TestProfilerIntegration:
     def test_profile_all_column_types(self, duckdb_path: str) -> None:
         """Profile all column types in one model."""
         models = {
-            "model.test.orders": _make_model(columns=[
-                {"name": "order_id", "data_type": "INTEGER"},
-                {"name": "customer_id", "data_type": "INTEGER"},
-                {"name": "status", "data_type": "VARCHAR"},
-                {"name": "amount", "data_type": "DECIMAL(10,2)"},
-                {"name": "order_date", "data_type": "DATE"},
-                {"name": "is_active", "data_type": "BOOLEAN"},
-            ]),
+            "model.test.orders": _make_model(
+                columns=[
+                    {"name": "order_id", "data_type": "INTEGER"},
+                    {"name": "customer_id", "data_type": "INTEGER"},
+                    {"name": "status", "data_type": "VARCHAR"},
+                    {"name": "amount", "data_type": "DECIMAL(10,2)"},
+                    {"name": "order_date", "data_type": "DATE"},
+                    {"name": "is_active", "data_type": "BOOLEAN"},
+                ]
+            ),
         }
 
         profiles = profile_models(

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -1,9 +1,8 @@
 """Tests for the file watcher."""
 
 import time
-from pathlib import Path
 
-from docglow.server.watcher import _get_mtimes, WATCH_PATTERNS
+from docglow.server.watcher import _get_mtimes
 
 
 class TestGetMtimes:


### PR DESCRIPTION
## Summary
- Fix all ruff lint errors (E501 line-too-long, E741 ambiguous names, F401 unused imports)
- Fix all mypy type-check errors (missing stubs, no-any-return, type-arg, call-overload)
- Fix hardcoded version in test to use dynamic `__version__`
- Auto-format all files with ruff

## Test plan
- [ ] CI lint job passes
- [ ] CI type-check job passes
- [ ] CI test matrix passes across Python 3.10–3.13