### PR TITLE
fix: resolve CI lint errors and add pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.10
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/src/docglow/cli.py
+++ b/src/docglow/cli.py
@@ -98,8 +98,7 @@ def generate(
 
     # Security warning for AI mode
     if ai:
-        err_console = Console(stderr=True)
-        err_console.print(
+        console.print(
             "\n[bold yellow]Warning:[/bold yellow] AI mode embeds your API key "
             "in the generated site.\n"
             "  This is safe for local use but do [bold]NOT[/bold] deploy this "

--- a/tests/test_cli_fail_under.py
+++ b/tests/test_cli_fail_under.py
@@ -3,11 +3,9 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
 from click.testing import CliRunner
 
 from docglow.cli import cli
-
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -1,7 +1,7 @@
 """Tests for docglow init command."""
+
 from pathlib import Path
 
-import pytest
 import yaml
 from click.testing import CliRunner
 

--- a/tests/test_cli_warnings.py
+++ b/tests/test_cli_warnings.py
@@ -3,7 +3,6 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
 from click.testing import CliRunner
 
 from docglow.cli import cli
@@ -21,7 +20,7 @@ class TestAiKeySecurityWarning:
 
     def test_ai_flag_prints_security_warning(self, tmp_path: Path) -> None:
         """When --ai is used, a security warning should be printed."""
-        runner = CliRunner(mix_stderr=False)
+        runner = CliRunner()
         with (
             patch("docglow.config.load_config", return_value=self._make_mock_config()),
             patch("docglow.generator.site.generate_site", side_effect=SystemExit(0)),
@@ -32,13 +31,12 @@ class TestAiKeySecurityWarning:
                 catch_exceptions=False,
             )
 
-        combined = (result.output or "") + (result.stderr or "")
-        assert "api key" in combined.lower()
-        assert "do not deploy" in combined.lower()
+        assert "api key" in result.output.lower()
+        assert "do not deploy" in result.output.lower()
 
     def test_ai_key_flag_prints_security_warning(self, tmp_path: Path) -> None:
         """When --ai-key is used, a security warning should be printed."""
-        runner = CliRunner(mix_stderr=False)
+        runner = CliRunner()
         with (
             patch("docglow.config.load_config", return_value=self._make_mock_config()),
             patch("docglow.generator.site.generate_site", side_effect=SystemExit(0)),
@@ -47,18 +45,19 @@ class TestAiKeySecurityWarning:
                 cli,
                 [
                     "generate",
-                    "--project-dir", str(tmp_path),
-                    "--ai-key", "sk-test-fake-key",
+                    "--project-dir",
+                    str(tmp_path),
+                    "--ai-key",
+                    "sk-test-fake-key",
                 ],
                 catch_exceptions=False,
             )
 
-        combined = (result.output or "") + (result.stderr or "")
-        assert "api key" in combined.lower()
+        assert "api key" in result.output.lower()
 
     def test_no_ai_no_warning(self, tmp_path: Path) -> None:
         """When --ai is NOT used, no security warning should appear."""
-        runner = CliRunner(mix_stderr=False)
+        runner = CliRunner()
         with (
             patch("docglow.config.load_config", return_value=self._make_mock_config()),
             patch("docglow.generator.site.generate_site", side_effect=SystemExit(0)),
@@ -69,5 +68,4 @@ class TestAiKeySecurityWarning:
                 catch_exceptions=False,
             )
 
-        combined = (result.output or "") + (result.stderr or "")
-        assert "api key" not in combined.lower()
+        assert "api key" not in result.output.lower()

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -229,7 +229,9 @@ class TestLoadArtifacts:
         assert len(result.catalog.nodes) == 0
         assert len(result.catalog.sources) == 0
 
-    def test_missing_catalog_logs_warning(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    def test_missing_catalog_logs_warning(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
         """Missing catalog.json logs a specific warning."""
         target = tmp_path / "target"
         target.mkdir()


### PR DESCRIPTION
## Summary

Fixes the CI failures from [run #23093539306](https://github.com/docglow/docglow/actions/runs/23093539306).

### Lint fixes
- Remove unused `pytest` imports from 3 test files
- Fix import sorting in `test_cli_fail_under.py`
- Fix line-too-long in `test_loader.py` (106 > 100 chars)
- Apply `ruff format` to 2 test files

### Compatibility fix
- `CliRunner(mix_stderr=False)` is not supported in Click 8.1 — changed AI warning to use stdout `console.print` instead of `Console(stderr=True)` so tests work across all Click versions

### Prevention
- Added `.pre-commit-config.yaml` with ruff lint + format hooks
- Running `pre-commit install` will auto-check lint/format on every commit

## Test plan

- [x] `ruff check src/ tests/` passes
- [x] `ruff format --check src/ tests/` passes
- [x] `mypy src/docglow` passes
- [x] 159 pytest tests passing
- [x] Pre-commit hooks pass on this commit