### PR TITLE
fix: static site data injection order and missing favicon

### DIFF
--- a/src/docglow/generator/bundle.py
+++ b/src/docglow/generator/bundle.py
@@ -86,17 +86,25 @@ def _bundle_static(
     frontend_dist: Path,
 ) -> None:
     """Bundle everything into a single index.html."""
+    import re
+    import shutil
+
     index_path = frontend_dist / "index.html"
     html = index_path.read_text(encoding="utf-8")
 
     data_json = json.dumps(docglow_data, separators=(",", ":"))
     data_script = f"<script>window.__DOCGLOW_DATA__={data_json};</script>"
 
-    # Inject data script before closing </head> tag
-    html = html.replace("</head>", f"{data_script}\n</head>")
+    # Inject data script BEFORE the first <script> tag so the app JS can read it
+    html = re.sub(r"(<script)", f"{data_script}\n\\1", html, count=1)
 
     # Inline CSS and JS assets
     html = _inline_assets(html, frontend_dist)
+
+    # Copy favicon if present
+    favicon_path = frontend_dist / "favicon.svg"
+    if favicon_path.exists():
+        shutil.copy2(favicon_path, output_dir / "favicon.svg")
 
     output_path = output_dir / "index.html"
     output_path.write_text(html, encoding="utf-8")


### PR DESCRIPTION
## Summary

Fixes the blank page and React error on the GitHub Pages demo site at https://docglow.github.io/docglow/.

### Root cause

In `--static` mode, the `__DOCGLOW_DATA__` script was injected **after** the app JS in the HTML `<head>`. The app JS ran first, found `window.__DOCGLOW_DATA__` undefined, fell through to `fetchData('./docglow-data.json')` which 404'd on GitHub Pages, and React crashed.

### Fix

1. Inject the data script **before** the first `<script>` tag so it's available when the app initializes
2. Copy `favicon.svg` alongside `index.html` in static mode (was previously omitted, causing a 404)

## Test plan

- [x] 159 tests passing
- [x] `docglow generate --static` outputs both `index.html` and `favicon.svg`
- [x] Data script appears before app script in generated HTML