### PR TITLE
fix: add progress output to serve and column lineage analysis (fixes #59)

### DIFF
--- a/src/docglow/commands/serve.py
+++ b/src/docglow/commands/serve.py
@@ -12,6 +12,7 @@ import click
 @click.option("--dir", "serve_dir", type=click.Path(path_type=Path), default=None)
 @click.option("--watch", is_flag=True, help="Watch for artifact changes and auto-rebuild")
 @click.option("--project-dir", type=click.Path(exists=True, path_type=Path), default=".")
+@click.option("--verbose", is_flag=True, help="Enable debug logging")
 def serve(
     port: int,
     host: str,
@@ -19,10 +20,13 @@ def serve(
     serve_dir: Path | None,
     watch: bool,
     project_dir: Path,
+    verbose: bool,
 ) -> None:
     """Serve the documentation site locally."""
-    from docglow.cli import console
+    from docglow.cli import _setup_logging, console
     from docglow.server.dev import start_server
+
+    _setup_logging(verbose)
 
     resolved_dir = serve_dir or Path("target/docglow")
     if not resolved_dir.exists():
@@ -31,6 +35,12 @@ def serve(
             "Run [bold]docglow generate[/bold] first."
         )
         raise SystemExit(1)
+
+    # Show file count for feedback
+    file_count = len(list(resolved_dir.iterdir()))
+    console.print(f"\n[bold]docglow[/bold] Serving {file_count} files from {resolved_dir}")
+    console.print(f"  Local: [bold cyan]http://{host}:{port}[/bold cyan]")
+    console.print("  Press [bold]Ctrl+C[/bold] to stop\n")
 
     if watch:
         from docglow.server.watcher import start_watcher

--- a/src/docglow/lineage/analyzer.py
+++ b/src/docglow/lineage/analyzer.py
@@ -91,6 +91,11 @@ def analyze_column_lineage(
             len(all_models),
         )
 
+    # Count models to analyze for progress reporting
+    models_to_analyze = subset if subset is not None else set(all_models.keys())
+    analyzable_count = len(models_to_analyze & set(all_models.keys()))
+    analyzed_count = 0
+
     for uid, data in all_models.items():
         # Subset filtering: skip models outside the subset but include cached results
         if subset is not None and uid not in subset:
@@ -110,6 +115,7 @@ def analyze_column_lineage(
                 sql = raw
 
         if not sql or not sql.strip():
+            analyzed_count += 1
             continue
 
         total_models += 1
@@ -122,7 +128,17 @@ def analyze_column_lineage(
             if cached_lineage:
                 column_lineage[uid] = cached_lineage
             cache_hits += 1
+            analyzed_count += 1
             continue
+
+        analyzed_count += 1
+        model_name = data.get("name", uid.split(".")[-1])
+        logger.info(
+            "Column lineage: analyzing %s (%d/%d)",
+            model_name,
+            analyzed_count,
+            analyzable_count,
+        )
 
         known_columns = [col["name"] for col in data.get("columns", []) if col.get("name")]
 
@@ -134,7 +150,7 @@ def analyze_column_lineage(
                 known_columns=known_columns or None,
             )
         except Exception as e:  # noqa: BLE001
-            logger.debug("Failed to parse column lineage for %s", uid)
+            logger.debug("Failed to parse column lineage for %s: %s", uid, e)
             parse_failures += 1
             failure_details.append(
                 {

--- a/src/docglow/server/dev.py
+++ b/src/docglow/server/dev.py
@@ -30,11 +30,14 @@ def start_server(
     server = HTTPServer((host, port), handler)
 
     url = f"http://{host}:{port}"
-    logger.info("Serving docglow at %s", url)
-    logger.info("Press Ctrl+C to stop")
+    logger.debug("Server bound to %s:%d, serving from %s", host, port, directory)
 
     if open_browser:
-        webbrowser.open(url)
+        try:
+            webbrowser.open(url)
+            logger.debug("Browser opened at %s", url)
+        except Exception:
+            logger.debug("Could not open browser automatically")
 
     try:
         server.serve_forever()


### PR DESCRIPTION
## Summary
Fixes #59 — `docglow serve` and column lineage analysis appeared to hang with no output.

### Serve command
- Print server URL and file count via Rich console immediately (was silently using logger.info without configured logging)
- Add `--verbose` flag for debug output
- Wrap `webbrowser.open()` in try/except to prevent hangs on WSL/headless

### Column lineage analysis
- Add per-model progress logging: `Column lineage: analyzing model_name (X/169)`
- Users can now see exactly which model is being analyzed and how far through the process they are

**Before:** No output, appears to hang
**After:**
```
docglow Serving 7 files from ./site
  Local: http://127.0.0.1:8081
  Press Ctrl+C to stop
```

```
INFO  Column lineage: analyzing opportunity_prep (19/169)
INFO  Column lineage: analyzing account_prep (20/169)
```

## Test plan
- [x] All 487 tests pass, mypy clean
- [x] `docglow serve --no-open` shows output immediately
- [x] Column lineage shows per-model progress

Closes #59