### PR TITLE
fix: add verbose request logging and large file warnings to serve (#61)

### DIFF
--- a/src/docglow/commands/serve.py
+++ b/src/docglow/commands/serve.py
@@ -5,6 +5,15 @@ from pathlib import Path
 import click
 
 
+def _format_size(size_bytes: int) -> str:
+    """Format byte count to human-readable string."""
+    if size_bytes < 1024:
+        return f"{size_bytes} B"
+    if size_bytes < 1024 * 1024:
+        return f"{size_bytes / 1024:.1f} KB"
+    return f"{size_bytes / (1024 * 1024):.1f} MB"
+
+
 @click.command()
 @click.option("--port", type=int, default=8081)
 @click.option("--host", type=str, default="127.0.0.1")
@@ -24,7 +33,6 @@ def serve(
 ) -> None:
     """Serve the documentation site locally."""
     from docglow.cli import _setup_logging, console
-    from docglow.server.dev import start_server
 
     _setup_logging(verbose)
 
@@ -36,15 +44,36 @@ def serve(
         )
         raise SystemExit(1)
 
-    # Show file count for feedback
-    file_count = len(list(resolved_dir.iterdir()))
+    # Show file info
+    files = list(resolved_dir.iterdir())
+    file_count = len(files)
     console.print(f"\n[bold]docglow[/bold] Serving {file_count} files from {resolved_dir}")
+
+    # Check for data file and warn if large
+    data_file = resolved_dir / "docglow-data.json"
+    if data_file.exists():
+        data_size = data_file.stat().st_size
+        size_str = _format_size(data_size)
+        console.print(f"  Data: docglow-data.json ({size_str})")
+        if data_size > 15 * 1024 * 1024:  # > 15 MB
+            console.print(
+                f"  [yellow]Warning:[/yellow] Large data file ({size_str}). "
+                "Browser may be slow to load."
+            )
+            console.print(
+                "  Tip: Use [bold]--static[/bold] mode or [bold]--slim[/bold] to reduce file size."
+            )
+
     console.print(f"  Local: [bold cyan]http://{host}:{port}[/bold cyan]")
+    if verbose:
+        console.print("  Verbose: request logging enabled")
     console.print("  Press [bold]Ctrl+C[/bold] to stop\n")
 
     if watch:
         from docglow.server.watcher import start_watcher
 
         start_watcher(project_dir, resolved_dir, console)
+
+    from docglow.server.dev import start_server
 
     start_server(resolved_dir, host=host, port=port, open_browser=open)

--- a/src/docglow/server/dev.py
+++ b/src/docglow/server/dev.py
@@ -4,11 +4,26 @@ from __future__ import annotations
 
 import functools
 import logging
+import sys
 import webbrowser
 from http.server import HTTPServer, SimpleHTTPRequestHandler
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+
+class _DocglowHandler(SimpleHTTPRequestHandler):
+    """Custom handler with request logging and proper MIME types."""
+
+    def log_message(self, format: str, *args: object) -> None:
+        """Log HTTP requests via the module logger instead of stderr."""
+        logger.info(format, *args)
+
+    def end_headers(self) -> None:
+        """Add CORS and cache headers for local dev."""
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Cache-Control", "no-cache")
+        super().end_headers()
 
 
 def start_server(
@@ -26,8 +41,15 @@ def start_server(
         port: Port to listen on.
         open_browser: Whether to auto-open the browser.
     """
-    handler = functools.partial(SimpleHTTPRequestHandler, directory=str(directory))
-    server = HTTPServer((host, port), handler)
+    handler = functools.partial(_DocglowHandler, directory=str(directory))
+
+    try:
+        server = HTTPServer((host, port), handler)
+    except OSError as e:
+        logger.error("Could not start server on %s:%d — %s", host, port, e)
+        if "Address already in use" in str(e):
+            logger.error("Try a different port: docglow serve --port 8082")
+        sys.exit(1)
 
     url = f"http://{host}:{port}"
     logger.debug("Server bound to %s:%d, serving from %s", host, port, directory)


### PR DESCRIPTION
## Summary
Adds diagnostics to help troubleshoot #61 (blank screen on large projects).

### Changes
- **`--verbose` request logging**: Every HTTP request is logged so users can see if the browser is actually fetching files
- **Data file size shown at startup**: `Data: docglow-data.json (22.4 MB)`
- **Large file warning**: When >15MB, suggests `--static` or `--slim` to reduce size
- **Port-in-use error**: Clear message with suggestion to try a different port
- **CORS + no-cache headers**: Prevents stale responses during local dev

### Output example
```
docglow Serving 7 files from ./site
  Data: docglow-data.json (22.4 MB)
  Warning: Large data file (22.4 MB). Browser may be slow to load.
  Tip: Use --static mode or --slim to reduce file size.
  Local: http://127.0.0.1:8081
  Press Ctrl+C to stop

INFO  "GET / HTTP/1.1" 200 -
INFO  "GET /docglow-data.json HTTP/1.1" 200 -
```

## Test plan
- [x] All 487 tests pass, mypy clean
- [x] Verbose mode logs requests
- [x] Large file warning appears for 22MB JSON
- [x] Port-in-use shows clear error