### PR TITLE
fix: include subquery count in complexity threshold check

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,6 +39,7 @@ health:
     high_sql_lines: 200         # Max SQL lines before flagging
     high_join_count: 8          # Max joins before flagging
     high_cte_count: 10          # Max CTEs before flagging
+    high_subquery_count: 5      # Max subqueries before flagging
 
 profiling:
   enabled: false                # Enable column profiling

--- a/docs/health-scoring.md
+++ b/docs/health-scoring.md
@@ -62,6 +62,7 @@ health:
     high_sql_lines: 200    # Max SQL lines before flagging (default: 200)
     high_join_count: 8      # Max joins before flagging (default: 8)
     high_cte_count: 10      # Max CTEs before flagging (default: 10)
+    high_subquery_count: 5  # Max subqueries before flagging (default: 5)
 ```
 
 ### Naming conventions

--- a/src/docglow/analyzer/complexity.py
+++ b/src/docglow/analyzer/complexity.py
@@ -83,6 +83,7 @@ def analyze_complexity(
             sql_lines > thresholds.high_sql_lines
             or join_count > thresholds.high_join_count
             or cte_count > thresholds.high_cte_count
+            or subquery_count > thresholds.high_subquery_count
         )
 
         if is_high:
@@ -103,7 +104,10 @@ def analyze_complexity(
         )
 
     # Sort by complexity indicators (most complex first)
-    results.sort(key=lambda m: m.sql_lines + m.join_count * 10 + m.cte_count * 5, reverse=True)
+    results.sort(
+        key=lambda m: m.sql_lines + m.join_count * 10 + m.cte_count * 5 + m.subquery_count * 8,
+        reverse=True,
+    )
 
     return ComplexityReport(
         models=results,

--- a/src/docglow/commands/init.py
+++ b/src/docglow/commands/init.py
@@ -30,6 +30,7 @@ INIT_TEMPLATE = """\
 #     high_sql_lines: 200
 #     high_join_count: 8
 #     high_cte_count: 10
+#     high_subquery_count: 5
 
 # profiling:
 #   enabled: false

--- a/src/docglow/config.py
+++ b/src/docglow/config.py
@@ -45,6 +45,7 @@ class ComplexityThresholds:
     high_sql_lines: int = 200
     high_join_count: int = 8
     high_cte_count: int = 10
+    high_subquery_count: int = 5
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary
Subquery count was tracked and displayed in the complexity report but never included in the `is_high_complexity` determination. A model with 31 subqueries was not flagged as high complexity.

### Changes
- Add `subquery_count > threshold` to the `is_high` check in `complexity.py`
- Add `high_subquery_count: 5` to `ComplexityThresholds` (configurable in `docglow.yml`)
- Include subqueries in the sort key weighting
- Updated docs: health-scoring, configuration, init template

### Configurable
```yaml
health:
  complexity:
    high_subquery_count: 5  # default
```

## Test plan
- [x] All 487 tests pass, mypy clean
- [x] Config parser picks up the new field automatically