### PR TITLE
docs: add Docglow Cloud waitlist links to README and docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,21 @@ docglow generate --project-dir /path/to/dbt --static
 
 The entire site (data, styles, JavaScript) is embedded in one file. Perfect for sharing via email, Slack, or committing to a repository.
 
+## Docglow Cloud
+
+**Hosted documentation with AI features — coming soon.**
+
+Everything in the open-source CLI, plus:
+
+- **AI-powered Q&A** — ask natural language questions about your dbt project
+- **Slack bot** — answer data questions where your team already works
+- **Hosted doc sites** — publish with `docglow publish`, share a link
+- **Project health dashboard** — track documentation quality over time
+
+Unlimited models, unlimited viewers. You only pay for AI features you use.
+
+**[Join the waitlist →](https://docglow.com/#cloud)**
+
 ## Configuration
 
 Add a `docglow.yml` to your dbt project root for optional customization (layer definitions, display settings, etc.). Docglow works out of the box without any configuration — just point it at a dbt project with compiled artifacts in `target/`.

--- a/docs/cloud.md
+++ b/docs/cloud.md
@@ -1,0 +1,49 @@
+# Docglow Cloud
+
+**Hosted documentation with AI features — coming soon.**
+
+Docglow Cloud takes everything you get from the open-source CLI and adds a managed hosting layer with AI-powered features for your team.
+
+## What's Included
+
+### AI-Powered Q&A
+
+Ask natural language questions about your dbt project — column definitions, model relationships, business logic — and get instant answers grounded in your actual documentation and SQL.
+
+### Slack Bot
+
+Your team shouldn't have to leave Slack to find answers about data. The Docglow Slack bot brings your documentation into the conversations where questions happen.
+
+### Hosted Doc Sites
+
+Publish your documentation with a single command:
+
+```bash
+pip install "docglow[cloud]"
+docglow login
+docglow publish
+```
+
+Share a link with your team — no infrastructure to manage, no CI/CD to configure.
+
+### Project Health Dashboard
+
+Track documentation quality over time. See which models are undocumented, untested, or drifting from naming conventions — and watch your scores improve.
+
+## Pricing
+
+Unlimited models, unlimited viewers. You only pay for AI features you use.
+
+| | Free | Starter | Team | Business |
+|---|---|---|---|---|
+| Projects | 1 | 1 | 3 | 10 |
+| Models | 50 | Unlimited | Unlimited | Unlimited |
+| AI queries/month | — | 100 | 500 | 2,000 |
+| Custom domain | — | — | :material-check: | :material-check: |
+| Slack bot | — | — | :material-check: | :material-check: |
+
+## Join the Waitlist
+
+We're onboarding early access users now. Leave your email and we'll reach out when it's ready.
+
+[Join the waitlist →](https://docglow.com/#cloud){ .md-button .md-button--primary }

--- a/docs/cloud.md
+++ b/docs/cloud.md
@@ -8,7 +8,7 @@ Docglow Cloud takes everything you get from the open-source CLI and adds a manag
 
 ### AI-Powered Q&A
 
-Ask natural language questions about your dbt project — column definitions, model relationships, business logic — and get instant answers grounded in your actual documentation and SQL.
+Ask natural language questions about your dbt project: column definitions, model relationships, and business logic. Get instant answers grounded in your actual documentation and SQL.
 
 ### Slack Bot
 
@@ -24,7 +24,7 @@ docglow login
 docglow publish
 ```
 
-Share a link with your team — no infrastructure to manage, no CI/CD to configure.
+Share a link with your team. No infrastructure to manage, no CI/CD to configure.
 
 ### Project Health Dashboard
 
@@ -32,15 +32,22 @@ Track documentation quality over time. See which models are undocumented, untest
 
 ## Pricing
 
-Unlimited models, unlimited viewers. You only pay for AI features you use.
+Unlimited models, unlimited viewers. 14-day free trial on all plans.
 
-| | Free | Starter | Team | Business |
-|---|---|---|---|---|
-| Projects | 1 | 1 | 3 | 10 |
-| Models | 50 | Unlimited | Unlimited | Unlimited |
-| AI queries/month | — | 100 | 500 | 2,000 |
-| Custom domain | — | — | :material-check: | :material-check: |
-| Slack bot | — | — | :material-check: | :material-check: |
+|  | Pro — $99/mo | Business — $299/mo |
+|---|---|---|
+| **Projects** | 3 | Unlimited |
+| **Models** | Unlimited | Unlimited |
+| **Viewers** | Unlimited | Unlimited |
+| **AI queries/mo** | 500 | 5,000 |
+| **Slack bot** | :material-check: | :material-check: |
+| **AI doc generation** | :material-check: | :material-check: |
+| **Health dashboard** | 90 days | 1 year |
+| **Custom domain** | :material-check: | :material-check: |
+| **SSO/SAML** | — | :material-check: |
+| **Support** | Email | Priority email + Slack |
+
+500 AI queries/mo included on the Pro plan and 5,000 AI queries/mo included on the Business plan. Need more? Additional queries at $0.10 each on Business and $0.20 each on Pro.
 
 ## Join the Waitlist
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,11 @@ Thousands of teams use dbt Core without access to dbt Cloud's documentation feat
 
 Docglow replaces it with a **modern, interactive single-page application** — and it works with any dbt Core project out of the box.
 
+!!! tip "Docglow Cloud (coming soon)"
+    Hosted docs, AI-powered Q&A, Slack bot, and project health dashboards.
+    Unlimited models, unlimited viewers.
+    **[Join the waitlist →](https://docglow.com/#cloud)**
+
 ## Key Features
 
 - **Interactive lineage explorer** — drag, filter, and trace upstream/downstream dependencies with configurable depth and layer visualization

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,3 +78,4 @@ nav:
   - Reference:
     - CLI Commands: reference/cli.md
     - Compatibility: compatibility.md
+  - Cloud: cloud.md


### PR DESCRIPTION
## Summary

Closes DOC-151

- Adds "Docglow Cloud" section to **README.md** after Single-File Mode with feature highlights and waitlist CTA
- Adds admonition banner to **docs/index.md** homepage with waitlist link
- Creates dedicated **docs/cloud.md** page with feature descriptions, pricing tier table, and waitlist CTA
- Adds Cloud entry to MkDocs nav in **mkdocs.yml**

All links point to the existing Formspree-powered waitlist form at `docglow.com/#cloud` — no new form infrastructure needed.

## Test plan
- [ ] Verify CI passes
- [ ] Check README renders correctly on GitHub (Cloud section visible after Single-File Mode)
- [ ] Verify MkDocs build succeeds (confirmed locally)
- [ ] Check docs.docglow.com after deploy: admonition on homepage, Cloud nav entry, cloud.md page
- [ ] Confirm waitlist links resolve to docglow.com/#cloud and open the modal