### PR TITLE
perf: parallelize column lineage parsing (~3.4x speedup)

### DIFF
--- a/scripts/bench_column_lineage.py
+++ b/scripts/bench_column_lineage.py
@@ -1,0 +1,151 @@
+"""Benchmark column lineage performance against a real dbt project.
+
+Usage:
+    python scripts/bench_column_lineage.py /path/to/dbt/project
+    python scripts/bench_column_lineage.py /path/to/dbt/project --no-cache
+    python scripts/bench_column_lineage.py /path/to/dbt/project --select fct_orders+
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import time
+from pathlib import Path
+from typing import Any
+
+
+def _setup_pipeline_context(
+    project_dir: Path,
+) -> tuple[
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+    Any,
+    str | None,
+]:
+    """Run pipeline stages up through transform to get model/source dicts.
+
+    Returns (models, sources, seeds, snapshots, manifest, dialect).
+    """
+    from docglow.artifacts.loader import load_artifacts
+    from docglow.generator.pipeline import (
+        PipelineContext,
+        stage_filter_nodes,
+        stage_transform_nodes,
+        stage_transform_sources,
+    )
+    from docglow.lineage.column_parser import detect_dialect
+
+    artifacts = load_artifacts(project_dir)
+
+    ctx = PipelineContext(
+        artifacts=artifacts,
+        column_lineage_enabled=True,
+    )
+
+    # Run the transform stages that build the model/source dicts
+    stage_transform_nodes(ctx)
+    stage_filter_nodes(ctx)
+    stage_transform_sources(ctx)
+
+    dialect = detect_dialect(artifacts.manifest.metadata.adapter_type)
+
+    return ctx.models, ctx.sources, ctx.seeds, ctx.snapshots, artifacts.manifest, dialect
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Benchmark column lineage performance")
+    parser.add_argument("project_dir", type=Path, help="Path to dbt project root")
+    parser.add_argument("--no-cache", action="store_true", help="Clear cache before running")
+    parser.add_argument(
+        "--select", type=str, default=None, help="Subset pattern (e.g. fct_orders+)"
+    )
+    parser.add_argument("--verbose", action="store_true", help="Enable debug logging")
+    args = parser.parse_args()
+
+    log_level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(level=log_level, format="%(levelname)s %(name)s: %(message)s")
+
+    project_dir = args.project_dir.resolve()
+    cache_path = project_dir / "target" / ".bench-column-lineage-cache.json"
+
+    if args.no_cache and cache_path.exists():
+        cache_path.unlink()
+        print(f"Cleared cache: {cache_path}")
+
+    # Phase 1: Load and transform artifacts
+    print(f"\nLoading artifacts from {project_dir}...")
+    t0 = time.perf_counter()
+    models, sources, seeds, snapshots, manifest, dialect = _setup_pipeline_context(project_dir)
+    t_load = time.perf_counter() - t0
+
+    total_columns = sum(len(m.get("columns", [])) for m in models.values())
+
+    print(f"  Models:    {len(models)}")
+    print(f"  Sources:   {len(sources)}")
+    print(f"  Seeds:     {len(seeds)}")
+    print(f"  Snapshots: {len(snapshots)}")
+    print(f"  Columns:   {total_columns}")
+    print(f"  Dialect:   {dialect}")
+    print(f"  Load time: {t_load:.1f}s")
+
+    # Phase 2: Compute subset if requested
+    subset = None
+    if args.select:
+        from docglow.lineage.analyzer import compute_column_lineage_subset
+
+        subset = compute_column_lineage_subset(
+            pattern=args.select,
+            models=models,
+            sources=sources,
+            seeds=seeds,
+            snapshots=snapshots,
+        )
+        print(f"\n  Subset:    {len(subset)} models (pattern: {args.select})")
+
+    # Phase 3: Run column lineage analysis (the thing we're benchmarking)
+    from docglow.lineage.analyzer import analyze_column_lineage
+
+    print("\nRunning column lineage analysis...")
+    t1 = time.perf_counter()
+    result = analyze_column_lineage(
+        models=models,
+        sources=sources,
+        seeds=seeds,
+        snapshots=snapshots,
+        dialect=dialect,
+        manifest_nodes=dict(manifest.nodes),
+        manifest_sources=dict(manifest.sources),
+        cache_path=cache_path,
+        subset=subset,
+    )
+    t_lineage = time.perf_counter() - t1
+
+    # Phase 4: Report results
+    total_deps = sum(
+        len(deps) for model_lineage in result.values() for deps in model_lineage.values()
+    )
+    traced_columns = sum(len(cols) for cols in result.values())
+
+    print(f"\n{'=' * 50}")
+    print("  RESULTS")
+    print(f"{'=' * 50}")
+    print(f"  Models with lineage:  {len(result)}")
+    print(f"  Columns traced:       {traced_columns}")
+    print(f"  Total dependencies:   {total_deps}")
+    print(f"  Lineage time:         {t_lineage:.1f}s")
+    print(f"  Total time:           {t_load + t_lineage:.1f}s")
+
+    if len(models) > 0:
+        print(f"  Avg per model:        {t_lineage / len(models) * 1000:.0f}ms")
+    if traced_columns > 0:
+        print(f"  Avg per column:       {t_lineage / traced_columns * 1000:.0f}ms")
+
+    print(f"  Cache:                {cache_path}")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_column_lineage.py
+++ b/scripts/bench_column_lineage.py
@@ -62,6 +62,7 @@ def main() -> None:
     parser.add_argument(
         "--select", type=str, default=None, help="Subset pattern (e.g. fct_orders+)"
     )
+    parser.add_argument("--workers", type=int, default=None, help="Max parallel workers")
     parser.add_argument("--verbose", action="store_true", help="Enable debug logging")
     args = parser.parse_args()
 
@@ -120,6 +121,7 @@ def main() -> None:
         manifest_sources=dict(manifest.sources),
         cache_path=cache_path,
         subset=subset,
+        max_workers=args.workers,
     )
     t_lineage = time.perf_counter() - t1
 

--- a/src/docglow/__init__.py
+++ b/src/docglow/__init__.py
@@ -1,3 +1,3 @@
 """docglow: Next-generation dbt documentation site generator."""
 
-__version__ = "0.5.5"
+__version__ = "0.6.0"

--- a/src/docglow/commands/generate.py
+++ b/src/docglow/commands/generate.py
@@ -68,6 +68,12 @@ import click
     default=None,
     help="Path to an HTML file whose contents are injected into <head> (e.g. analytics snippet)",
 )
+@click.option(
+    "--workers",
+    type=int,
+    default=None,
+    help="Max parallel workers for column lineage (default: auto)",
+)
 @click.option("--verbose", is_flag=True)
 @click.option(
     "--fail-under",
@@ -97,6 +103,7 @@ def generate(
     include_packages: bool,
     slim: bool,
     head_script: Path | None,
+    workers: int | None,
     verbose: bool,
     fail_under: float | None,
 ) -> None:
@@ -173,6 +180,7 @@ def generate(
             exclude_packages=not include_packages,
             slim=slim,
             head_script=head_script.read_text(encoding="utf-8") if head_script else None,
+            column_lineage_workers=workers,
         )
         console.print(f"\n[bold green]Site generated at {output_path}[/bold green]")
         if static:

--- a/src/docglow/generator/data.py
+++ b/src/docglow/generator/data.py
@@ -168,6 +168,7 @@ def build_docglow_data(
     column_lineage_select: str | None = None,
     column_lineage_depth: int | None = None,
     column_lineage_cache_dir: Any | None = None,
+    column_lineage_workers: int | None = None,
     exclude_packages: bool = True,
     slim: bool = False,
 ) -> dict[str, Any]:
@@ -194,6 +195,7 @@ def build_docglow_data(
         column_lineage_select=column_lineage_select,
         column_lineage_depth=column_lineage_depth,
         column_lineage_cache_dir=column_lineage_cache_dir,
+        column_lineage_workers=column_lineage_workers,
         exclude_packages=exclude_packages,
         slim=slim,
     )
@@ -214,6 +216,7 @@ def _build_column_lineage(
     sources: dict[str, Any],
     seeds: dict[str, Any],
     snapshots: dict[str, Any],
+    max_workers: int | None = None,
 ) -> dict[str, Any] | None:
     """Build column-level lineage if enabled."""
     if not enabled:
@@ -253,6 +256,7 @@ def _build_column_lineage(
             else _Path(".docglow-column-lineage-cache.json")
         ),
         subset=subset,
+        max_workers=max_workers,
     )
 
     # Backfill columns for models that have lineage but no catalog/manifest columns.

--- a/src/docglow/generator/pipeline.py
+++ b/src/docglow/generator/pipeline.py
@@ -36,6 +36,7 @@ class PipelineContext:
     column_lineage_select: str | None = None
     column_lineage_depth: int | None = None
     column_lineage_cache_dir: Any | None = None
+    column_lineage_workers: int | None = None
     exclude_packages: bool = True
     slim: bool = False
 
@@ -264,6 +265,7 @@ def stage_build_column_lineage(ctx: PipelineContext) -> None:
         ctx.sources,
         ctx.seeds,
         ctx.snapshots,
+        max_workers=ctx.column_lineage_workers,
     )
 
 

--- a/src/docglow/generator/site.py
+++ b/src/docglow/generator/site.py
@@ -35,6 +35,7 @@ def generate_site(
     exclude_packages: bool = True,
     slim: bool = False,
     head_script: str | None = None,
+    column_lineage_workers: int | None = None,
 ) -> tuple[Path, float]:
     """Generate the docglow static site.
 
@@ -77,6 +78,7 @@ def generate_site(
         column_lineage_select=column_lineage_select,
         column_lineage_depth=column_lineage_depth,
         column_lineage_cache_dir=resolved_output,
+        column_lineage_workers=column_lineage_workers,
         exclude_packages=exclude_packages,
         slim=slim,
     )

--- a/src/docglow/lineage/analyzer.py
+++ b/src/docglow/lineage/analyzer.py
@@ -6,8 +6,11 @@ import fnmatch
 import hashlib
 import json
 import logging
+import os
 import re
 from collections import deque
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -32,6 +35,195 @@ _JINJA_GENERIC = re.compile(r"\{\{.*?\}\}", re.DOTALL)
 _JINJA_BLOCK = re.compile(r"\{%.*?%\}", re.DOTALL)
 
 
+@dataclass
+class _ModelLineageResult:
+    """Result of analyzing column lineage for a single model."""
+
+    uid: str
+    lineage: dict[str, list[dict[str, str]]] = field(default_factory=dict)
+    cache_entry: dict[str, Any] = field(default_factory=dict)
+    failure: dict[str, str] | None = None
+    cached: bool = False
+    skipped: bool = False
+
+
+def _compute_depth_waves(
+    all_models: dict[str, dict[str, Any]],
+) -> list[list[str]]:
+    """Compute topological depth waves for parallel processing.
+
+    Returns a list of waves, where each wave contains model UIDs that can be
+    processed in parallel (all their upstream dependencies are in earlier waves).
+
+    Models with no in-set dependencies are in wave 0. Models whose dependencies
+    are all outside the set (e.g. sources) are also in wave 0.
+    """
+    model_uids = set(all_models.keys())
+
+    # Build in-degree map: only count dependencies that are within our model set
+    in_degree: dict[str, int] = {}
+    dependents: dict[str, list[str]] = {uid: [] for uid in model_uids}
+
+    for uid, data in all_models.items():
+        deps_in_set = [d for d in data.get("depends_on", []) if d in model_uids]
+        in_degree[uid] = len(deps_in_set)
+        for dep in deps_in_set:
+            dependents[dep].append(uid)
+
+    # BFS from roots (in-degree 0) to assign depth
+    waves: list[list[str]] = []
+    current_wave = [uid for uid, deg in in_degree.items() if deg == 0]
+
+    while current_wave:
+        waves.append(current_wave)
+        next_wave: list[str] = []
+        for uid in current_wave:
+            for dependent in dependents[uid]:
+                in_degree[dependent] -= 1
+                if in_degree[dependent] == 0:
+                    next_wave.append(dependent)
+        current_wave = next_wave
+
+    # Any remaining models (cycles) go in a final wave
+    processed = {uid for wave in waves for uid in wave}
+    remaining = [uid for uid in model_uids if uid not in processed]
+    if remaining:
+        waves.append(remaining)
+
+    return waves
+
+
+# Module-level state for worker processes (set by _init_worker)
+_worker_schema: dict[str, dict[str, str]] = {}
+_worker_resolver: TableResolver | None = None
+_worker_dialect: str | None = None
+
+
+def _init_worker(
+    schema: dict[str, dict[str, str]],
+    resolver: TableResolver,
+    dialect: str | None,
+) -> None:
+    """Initialize shared read-only state in each worker process."""
+    global _worker_schema, _worker_resolver, _worker_dialect  # noqa: PLW0603
+    _worker_schema = schema
+    _worker_resolver = resolver
+    _worker_dialect = dialect
+
+
+def _analyze_model_in_worker(
+    uid: str,
+    data: dict[str, Any],
+    cached_entry: dict[str, Any] | None,
+) -> _ModelLineageResult:
+    """Wrapper for _analyze_single_model that uses process-local shared state."""
+    return _analyze_single_model(
+        uid=uid,
+        data=data,
+        schema=_worker_schema,
+        resolver=_worker_resolver,  # type: ignore[arg-type]
+        dialect=_worker_dialect,
+        cached_entry=cached_entry,
+    )
+
+
+def _analyze_single_model(
+    uid: str,
+    data: dict[str, Any],
+    schema: dict[str, dict[str, str]],
+    resolver: TableResolver,
+    dialect: str | None,
+    cached_entry: dict[str, Any] | None,
+) -> _ModelLineageResult:
+    """Analyze column lineage for a single model. Pure function, no side effects.
+
+    All inputs are read-only. Returns a result struct that the caller merges
+    into shared state.
+    """
+    sql = data.get("compiled_sql", "")
+    if not sql:
+        raw = data.get("raw_sql", "")
+        if not raw:
+            return _ModelLineageResult(uid=uid, skipped=True)
+        if "{{" in raw or "{%" in raw:
+            sql = strip_jinja(raw)
+        else:
+            sql = raw
+
+    if not sql or not sql.strip():
+        return _ModelLineageResult(uid=uid, skipped=True)
+
+    sql_hash = _hash_sql(sql)
+
+    # Check cache
+    if cached_entry and cached_entry.get("sql_hash") == sql_hash:
+        cached_lineage = cached_entry.get("lineage")
+        return _ModelLineageResult(
+            uid=uid,
+            lineage=cached_lineage or {},
+            cache_entry=cached_entry,
+            cached=True,
+        )
+
+    known_columns = [col["name"] for col in data.get("columns", []) if col.get("name")]
+
+    try:
+        raw_lineage = parse_column_lineage(
+            compiled_sql=sql,
+            schema=schema,
+            dialect=dialect,
+            known_columns=known_columns or None,
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.debug("Failed to parse column lineage for %s: %s", uid, e)
+        return _ModelLineageResult(
+            uid=uid,
+            cache_entry={"sql_hash": sql_hash, "lineage": {}},
+            failure={
+                "model": uid,
+                "name": data.get("name", ""),
+                "error": str(e),
+            },
+        )
+
+    if not raw_lineage:
+        failure = None
+        if known_columns:
+            failure = {
+                "model": uid,
+                "name": data.get("name", ""),
+                "error": f"No columns traced ({len(known_columns)} columns in schema)",
+            }
+        return _ModelLineageResult(
+            uid=uid,
+            cache_entry={"sql_hash": sql_hash, "lineage": {}},
+            failure=failure,
+        )
+
+    model_lineage = _resolve_dependencies(raw_lineage, resolver)
+    cache_entry_out = {"sql_hash": sql_hash, "lineage": model_lineage}
+
+    # Track partially traced models
+    failure = None
+    if known_columns and len(model_lineage) < len(known_columns):
+        traced = set(model_lineage.keys())
+        missed = [c for c in known_columns if c not in traced]
+        if missed:
+            failure = {
+                "model": uid,
+                "name": data.get("name", ""),
+                "error": f"Partial: {len(missed)}/{len(known_columns)} columns not traced",
+                "columns": ", ".join(missed[:20]),
+            }
+
+    return _ModelLineageResult(
+        uid=uid,
+        lineage=model_lineage,
+        cache_entry=cache_entry_out,
+        failure=failure,
+    )
+
+
 def analyze_column_lineage(
     models: dict[str, dict[str, Any]],
     sources: dict[str, dict[str, Any]],
@@ -42,11 +234,15 @@ def analyze_column_lineage(
     manifest_sources: dict[str, Any] | None = None,
     cache_path: Path | None = None,
     subset: set[str] | None = None,
+    max_workers: int | None = None,
 ) -> dict[str, dict[str, list[dict[str, str]]]]:
     """Analyze column-level lineage for all models.
 
     Uses compiled_sql when available, falls back to raw_sql with Jinja
     stripped for models that haven't been compiled.
+
+    Models are processed in topological waves — all models at the same DAG
+    depth run in parallel using a thread pool.
 
     Args:
         models: Transformed model data from build_docglow_data.
@@ -59,6 +255,8 @@ def analyze_column_lineage(
         cache_path: Path to the column lineage cache file.
         subset: If provided, only analyze these model unique_ids.
             Models outside the subset still have their cached results included.
+        max_workers: Max parallel workers for lineage parsing.
+            Defaults to min(8, cpu_count + 4). Set to 1 for sequential.
 
     Returns:
         Dict of {model_unique_id: {column_name: [dependency_dicts]}}.
@@ -91,107 +289,106 @@ def analyze_column_lineage(
             len(all_models),
         )
 
-    # Count models to analyze for progress reporting
-    models_to_analyze = subset if subset is not None else set(all_models.keys())
-    analyzable_count = len(models_to_analyze & set(all_models.keys()))
-    analyzed_count = 0
+    # Subset filtering: include cached results for models outside subset
+    if subset is not None:
+        for uid in all_models:
+            if uid not in subset:
+                cached_entry = cache.get(uid)
+                if cached_entry and cached_entry.get("lineage"):
+                    column_lineage[uid] = cached_entry["lineage"]
 
-    for uid, data in all_models.items():
-        # Subset filtering: skip models outside the subset but include cached results
-        if subset is not None and uid not in subset:
-            cached_entry = cache.get(uid)
-            if cached_entry and cached_entry.get("lineage"):
-                column_lineage[uid] = cached_entry["lineage"]
-            continue
+    # Determine which models to analyze
+    uids_to_analyze = (
+        [uid for uid in all_models if uid in subset]
+        if subset is not None
+        else list(all_models.keys())
+    )
+    analyzable_count = len(uids_to_analyze)
 
-        sql = data.get("compiled_sql", "")
-        if not sql:
-            raw = data.get("raw_sql", "")
-            if not raw:
-                continue
-            if "{{" in raw or "{%" in raw:
-                sql = strip_jinja(raw)
-            else:
-                sql = raw
+    # Compute topological waves for parallel processing
+    analyze_set = {uid: all_models[uid] for uid in uids_to_analyze}
+    waves = _compute_depth_waves(analyze_set)
 
-        if not sql or not sql.strip():
-            analyzed_count += 1
-            continue
+    workers = max_workers if max_workers is not None else min(8, (os.cpu_count() or 1) + 4)
+    use_parallel = workers > 1 and analyzable_count > 1
 
-        total_models += 1
-        sql_hash = _hash_sql(sql)
-
-        # Check cache
-        cached_entry = cache.get(uid)
-        if cached_entry and cached_entry.get("sql_hash") == sql_hash:
-            cached_lineage = cached_entry.get("lineage")
-            if cached_lineage:
-                column_lineage[uid] = cached_lineage
-            cache_hits += 1
-            analyzed_count += 1
-            continue
-
-        analyzed_count += 1
-        model_name = data.get("name", uid.split(".")[-1])
+    if use_parallel:
         logger.info(
-            "Column lineage: analyzing %s (%d/%d)",
-            model_name,
-            analyzed_count,
+            "Column lineage: %d models in %d waves, %d workers",
             analyzable_count,
+            len(waves),
+            workers,
         )
 
-        known_columns = [col["name"] for col in data.get("columns", []) if col.get("name")]
+    analyzed_count = 0
 
-        try:
-            raw_lineage = parse_column_lineage(
-                compiled_sql=sql,
-                schema=schema,
-                dialect=dialect,
-                known_columns=known_columns or None,
-            )
-        except Exception as e:  # noqa: BLE001
-            logger.debug("Failed to parse column lineage for %s: %s", uid, e)
-            parse_failures += 1
-            failure_details.append(
-                {
-                    "model": uid,
-                    "name": data.get("name", ""),
-                    "error": str(e),
-                }
-            )
-            cache[uid] = {"sql_hash": sql_hash, "lineage": {}}
-            continue
+    if use_parallel:
+        # Submit ALL models to the pool at once. The pool's max_workers
+        # limit handles concurrency. We don't enforce wave ordering because
+        # models are currently independent (no inter-model deps during parsing).
+        # This avoids slow models in one wave blocking progress on others.
+        with ProcessPoolExecutor(
+            max_workers=workers,
+            initializer=_init_worker,
+            initargs=(schema, resolver, dialect),
+        ) as pool:
+            futures = {
+                pool.submit(
+                    _analyze_model_in_worker,
+                    uid,
+                    all_models[uid],
+                    cache.get(uid),
+                ): uid
+                for uid in uids_to_analyze
+            }
 
-        if not raw_lineage:
-            if known_columns:
-                failure_details.append(
-                    {
-                        "model": uid,
-                        "name": data.get("name", ""),
-                        "error": f"No columns traced ({len(known_columns)} columns in schema)",
-                    }
+            for future in as_completed(futures):
+                result = future.result()
+                analyzed_count += 1
+                _merge_result(
+                    result,
+                    all_models,
+                    column_lineage,
+                    cache,
+                    failure_details,
+                    analyzed_count,
+                    analyzable_count,
                 )
-            cache[uid] = {"sql_hash": sql_hash, "lineage": {}}
-            continue
-
-        model_lineage = _resolve_dependencies(raw_lineage, resolver)
-        cache[uid] = {"sql_hash": sql_hash, "lineage": model_lineage}
-        if model_lineage:
-            column_lineage[uid] = model_lineage
-
-        # Track partially traced models
-        if known_columns and len(model_lineage) < len(known_columns):
-            traced = set(model_lineage.keys())
-            missed = [c for c in known_columns if c not in traced]
-            if missed:
-                failure_details.append(
-                    {
-                        "model": uid,
-                        "name": data.get("name", ""),
-                        "error": f"Partial: {len(missed)}/{len(known_columns)} columns not traced",
-                        "columns": ", ".join(missed[:20]),
-                    }
+                if result.skipped:
+                    continue
+                total_models += 1
+                if result.cached:
+                    cache_hits += 1
+                elif result.failure:
+                    parse_failures += 1
+    else:
+        for wave_uids in waves:
+            for uid in wave_uids:
+                result = _analyze_single_model(
+                    uid=uid,
+                    data=all_models[uid],
+                    schema=schema,
+                    resolver=resolver,
+                    dialect=dialect,
+                    cached_entry=cache.get(uid),
                 )
+                analyzed_count += 1
+                _merge_result(
+                    result,
+                    all_models,
+                    column_lineage,
+                    cache,
+                    failure_details,
+                    analyzed_count,
+                    analyzable_count,
+                )
+                if result.skipped:
+                    continue
+                total_models += 1
+                if result.cached:
+                    cache_hits += 1
+                elif result.failure:
+                    parse_failures += 1
 
     if parse_failures > 0:
         logger.warning(
@@ -215,6 +412,44 @@ def analyze_column_lineage(
         _write_failure_report(failure_details, cache_path)
 
     return column_lineage
+
+
+def _merge_result(
+    result: _ModelLineageResult,
+    all_models: dict[str, dict[str, Any]],
+    column_lineage: dict[str, dict[str, list[dict[str, str]]]],
+    cache: dict[str, Any],
+    failure_details: list[dict[str, str]],
+    analyzed_count: int,
+    analyzable_count: int,
+) -> None:
+    """Merge a single model's lineage result into shared state.
+
+    Called sequentially (after future.result() in parallel mode, or directly
+    in sequential mode) so no locking is needed.
+    """
+    if result.skipped:
+        return
+
+    if result.cached:
+        if result.lineage:
+            column_lineage[result.uid] = result.lineage
+        return
+
+    model_name = all_models[result.uid].get("name", result.uid.split(".")[-1])
+    logger.info(
+        "Column lineage: analyzed %s (%d/%d)",
+        model_name,
+        analyzed_count,
+        analyzable_count,
+    )
+
+    if result.cache_entry:
+        cache[result.uid] = result.cache_entry
+    if result.lineage:
+        column_lineage[result.uid] = result.lineage
+    if result.failure:
+        failure_details.append(result.failure)
 
 
 def strip_jinja(raw_sql: str) -> str:

--- a/src/docglow/lineage/analyzer.py
+++ b/src/docglow/lineage/analyzer.py
@@ -161,7 +161,6 @@ def _analyze_single_model(
         return _ModelLineageResult(
             uid=uid,
             lineage=cached_lineage or {},
-            cache_entry=cached_entry,
             cached=True,
         )
 
@@ -241,8 +240,10 @@ def analyze_column_lineage(
     Uses compiled_sql when available, falls back to raw_sql with Jinja
     stripped for models that haven't been compiled.
 
-    Models are processed in topological waves — all models at the same DAG
-    depth run in parallel using a thread pool.
+    When the model count exceeds the parallel threshold, models are processed
+    concurrently using a process pool (bypasses the GIL for CPU-bound SQLGlot
+    parsing). Below the threshold or with max_workers=1, models run sequentially
+    in topological order.
 
     Args:
         models: Transformed model data from build_docglow_data.
@@ -256,7 +257,7 @@ def analyze_column_lineage(
         subset: If provided, only analyze these model unique_ids.
             Models outside the subset still have their cached results included.
         max_workers: Max parallel workers for lineage parsing.
-            Defaults to min(8, cpu_count + 4). Set to 1 for sequential.
+            Defaults to min(8, cpu_count). Set to 1 for sequential.
 
     Returns:
         Dict of {model_unique_id: {column_name: [dependency_dicts]}}.
@@ -305,28 +306,25 @@ def analyze_column_lineage(
     )
     analyzable_count = len(uids_to_analyze)
 
-    # Compute topological waves for parallel processing
-    analyze_set = {uid: all_models[uid] for uid in uids_to_analyze}
-    waves = _compute_depth_waves(analyze_set)
-
-    workers = max_workers if max_workers is not None else min(8, (os.cpu_count() or 1) + 4)
-    use_parallel = workers > 1 and analyzable_count > 1
-
-    if use_parallel:
-        logger.info(
-            "Column lineage: %d models in %d waves, %d workers",
-            analyzable_count,
-            len(waves),
-            workers,
-        )
+    # Process pool has meaningful startup cost (fork + serialize schema/resolver),
+    # so only use it when there are enough models to amortize the overhead.
+    parallel_threshold = 20
+    workers = max_workers if max_workers is not None else min(8, os.cpu_count() or 1)
+    use_parallel = workers > 1 and analyzable_count >= parallel_threshold
 
     analyzed_count = 0
 
     if use_parallel:
-        # Submit ALL models to the pool at once. The pool's max_workers
-        # limit handles concurrency. We don't enforce wave ordering because
-        # models are currently independent (no inter-model deps during parsing).
-        # This avoids slow models in one wave blocking progress on others.
+        logger.info(
+            "Column lineage: %d models, %d workers",
+            analyzable_count,
+            workers,
+        )
+
+        # Submit all models to the pool at once. Each model's parsing is
+        # independent (uses only its own SQL + the shared schema/resolver).
+        # Note: each model's data dict is pickled per submit() call — the
+        # compiled_sql strings dominate IPC cost for large models.
         with ProcessPoolExecutor(
             max_workers=workers,
             initializer=_init_worker,
@@ -354,14 +352,15 @@ def analyze_column_lineage(
                     analyzed_count,
                     analyzable_count,
                 )
-                if result.skipped:
-                    continue
-                total_models += 1
-                if result.cached:
-                    cache_hits += 1
-                elif result.failure:
-                    parse_failures += 1
+                if not result.skipped:
+                    total_models += 1
+                    if result.cached:
+                        cache_hits += 1
+                    elif result.failure:
+                        parse_failures += 1
     else:
+        # Sequential: process in topological order (upstream before downstream)
+        waves = _compute_depth_waves({uid: all_models[uid] for uid in uids_to_analyze})
         for wave_uids in waves:
             for uid in wave_uids:
                 result = _analyze_single_model(
@@ -382,13 +381,12 @@ def analyze_column_lineage(
                     analyzed_count,
                     analyzable_count,
                 )
-                if result.skipped:
-                    continue
-                total_models += 1
-                if result.cached:
-                    cache_hits += 1
-                elif result.failure:
-                    parse_failures += 1
+                if not result.skipped:
+                    total_models += 1
+                    if result.cached:
+                        cache_hits += 1
+                    elif result.failure:
+                        parse_failures += 1
 
     if parse_failures > 0:
         logger.warning(

--- a/src/docglow/lineage/column_parser.py
+++ b/src/docglow/lineage/column_parser.py
@@ -143,18 +143,34 @@ def parse_column_lineage(
     if has_star and output_columns:
         trace_sql = _rewrite_star_to_columns(compiled_sql, output_columns, dialect)
 
-    # Trace lineage for each output column with a per-column timeout
+    # Trace lineage for each output column with a per-column timeout.
+    # Reuse a single executor across all columns to avoid the overhead of
+    # creating/destroying a ThreadPoolExecutor for every column.
+    from concurrent.futures import ThreadPoolExecutor
+    from concurrent.futures import TimeoutError as FuturesTimeout
+
     result: dict[str, list[ColumnDependency]] = {}
     failures: list[str] = []
-    for col_name in output_columns:
-        try:
-            deps = _trace_column_with_timeout(col_name, trace_sql, schema or {}, dialect)
-            if deps:
-                result[col_name] = deps
-        except Exception as e:  # noqa: BLE001
-            logger.debug("Failed to trace lineage for column '%s': %s", col_name, e)
-            failures.append(col_name)
-            continue
+    resolved_schema = schema or {}
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        for col_name in output_columns:
+            try:
+                deps = _trace_column_in_executor(
+                    executor,
+                    col_name,
+                    trace_sql,
+                    resolved_schema,
+                    dialect,
+                )
+                if deps:
+                    result[col_name] = deps
+            except FuturesTimeout:
+                logger.debug("Timeout tracing lineage for column '%s'", col_name)
+                failures.append(col_name)
+            except Exception as e:  # noqa: BLE001
+                logger.debug("Failed to trace lineage for column '%s': %s", col_name, e)
+                failures.append(col_name)
 
     if failures:
         logger.debug(
@@ -166,20 +182,18 @@ def parse_column_lineage(
     return result
 
 
-def _trace_column_with_timeout(
+def _trace_column_in_executor(
+    executor: Any,
     col_name: str,
     sql: str,
     schema: dict[str, dict[str, str]],
     dialect: str | None,
     timeout_seconds: int = 2,
 ) -> list[ColumnDependency]:
-    """Trace lineage for a single column with a thread-safe timeout."""
-    from concurrent.futures import ThreadPoolExecutor
-    from concurrent.futures import TimeoutError as FuturesTimeout
-
+    """Trace lineage for a single column using a shared executor for timeout."""
     from sqlglot.lineage import lineage
 
-    def _trace() -> Any:
+    def _trace() -> list[ColumnDependency]:
         # Try with schema first (enables SELECT * expansion through CTEs).
         # If it fails, retry without schema (handles cases where schema
         # keys don't match SQL table references or columns are missing).
@@ -209,15 +223,9 @@ def _trace_column_with_timeout(
         except Exception:  # noqa: BLE001
             return []
 
-    with ThreadPoolExecutor(max_workers=1) as executor:
-        future = executor.submit(_trace)
-        try:
-            result: list[ColumnDependency] = future.result(timeout=timeout_seconds)
-            return result
-        except FuturesTimeout:
-            logger.debug("Timeout tracing lineage for column '%s'", col_name)
-            future.cancel()
-            return []
+    future = executor.submit(_trace)
+    result: list[ColumnDependency] = future.result(timeout=timeout_seconds)
+    return result
 
 
 def _rewrite_star_to_columns(

--- a/src/docglow/lineage/column_parser.py
+++ b/src/docglow/lineage/column_parser.py
@@ -191,6 +191,8 @@ def _trace_column_in_executor(
     timeout_seconds: int = 2,
 ) -> list[ColumnDependency]:
     """Trace lineage for a single column using a shared executor for timeout."""
+    from concurrent.futures import TimeoutError as FuturesTimeout
+
     from sqlglot.lineage import lineage
 
     def _trace() -> list[ColumnDependency]:
@@ -224,8 +226,14 @@ def _trace_column_in_executor(
             return []
 
     future = executor.submit(_trace)
-    result: list[ColumnDependency] = future.result(timeout=timeout_seconds)
-    return result
+    try:
+        return future.result(timeout=timeout_seconds)
+    except FuturesTimeout:
+        # Best-effort cancel — the thread may still be running since Python
+        # threads can't be forcibly interrupted, but this prevents the result
+        # from being collected if it finishes later.
+        future.cancel()
+        raise
 
 
 def _rewrite_star_to_columns(

--- a/src/docglow/lineage/column_parser.py
+++ b/src/docglow/lineage/column_parser.py
@@ -227,7 +227,8 @@ def _trace_column_in_executor(
 
     future = executor.submit(_trace)
     try:
-        return future.result(timeout=timeout_seconds)
+        result: list[ColumnDependency] = future.result(timeout=timeout_seconds)
+        return result
     except FuturesTimeout:
         # Best-effort cancel — the thread may still be running since Python
         # threads can't be forcibly interrupted, but this prevents the result

--- a/tests/test_column_lineage_parallel.py
+++ b/tests/test_column_lineage_parallel.py
@@ -1,0 +1,212 @@
+"""Tests for parallel column lineage analysis."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from docglow.artifacts.loader import load_artifacts
+from docglow.lineage.analyzer import (
+    _analyze_single_model,
+    _compute_depth_waves,
+    _ModelLineageResult,
+    analyze_column_lineage,
+)
+from docglow.lineage.column_parser import build_schema_mapping, detect_dialect
+from docglow.lineage.table_resolver import TableResolver
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+def _load_test_data() -> tuple[
+    dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any], Any, str | None
+]:
+    """Load jaffle-shop test fixtures and return transformed model dicts."""
+    from docglow.generator.pipeline import (
+        PipelineContext,
+        stage_filter_nodes,
+        stage_transform_nodes,
+        stage_transform_sources,
+    )
+
+    project = FIXTURES_DIR.parent.parent / "examples" / "jaffle-shop"
+    artifacts = load_artifacts(project)
+    ctx = PipelineContext(artifacts=artifacts, column_lineage_enabled=True)
+    stage_transform_nodes(ctx)
+    stage_filter_nodes(ctx)
+    stage_transform_sources(ctx)
+    dialect = detect_dialect(artifacts.manifest.metadata.adapter_type)
+    return ctx.models, ctx.sources, ctx.seeds, ctx.snapshots, artifacts.manifest, dialect
+
+
+class TestComputeDepthWaves:
+    """Test topological wave computation."""
+
+    def test_linear_chain(self) -> None:
+        """A -> B -> C should produce 3 waves."""
+        models = {
+            "a": {"depends_on": []},
+            "b": {"depends_on": ["a"]},
+            "c": {"depends_on": ["b"]},
+        }
+        waves = _compute_depth_waves(models)
+        assert len(waves) == 3
+        assert waves[0] == ["a"]
+        assert waves[1] == ["b"]
+        assert waves[2] == ["c"]
+
+    def test_diamond(self) -> None:
+        """Diamond: A -> B, A -> C, B -> D, C -> D."""
+        models = {
+            "a": {"depends_on": []},
+            "b": {"depends_on": ["a"]},
+            "c": {"depends_on": ["a"]},
+            "d": {"depends_on": ["b", "c"]},
+        }
+        waves = _compute_depth_waves(models)
+        assert len(waves) == 3
+        assert waves[0] == ["a"]
+        assert set(waves[1]) == {"b", "c"}
+        assert waves[2] == ["d"]
+
+    def test_wide_independent(self) -> None:
+        """All independent models should be in one wave."""
+        models = {
+            "a": {"depends_on": []},
+            "b": {"depends_on": []},
+            "c": {"depends_on": []},
+        }
+        waves = _compute_depth_waves(models)
+        assert len(waves) == 1
+        assert set(waves[0]) == {"a", "b", "c"}
+
+    def test_external_deps_ignored(self) -> None:
+        """Dependencies on sources (outside model set) don't block."""
+        models = {
+            "a": {"depends_on": ["source.external"]},
+            "b": {"depends_on": ["source.other"]},
+        }
+        waves = _compute_depth_waves(models)
+        assert len(waves) == 1
+        assert set(waves[0]) == {"a", "b"}
+
+    def test_empty(self) -> None:
+        waves = _compute_depth_waves({})
+        assert waves == []
+
+
+class TestAnalyzeSingleModel:
+    """Test the pure per-model analysis function."""
+
+    def test_returns_result_for_valid_sql(self) -> None:
+        models, sources, seeds, snapshots, manifest, dialect = _load_test_data()
+        schema = build_schema_mapping(models, sources)
+        resolver = TableResolver(
+            models=models,
+            sources=sources,
+            seeds=seeds,
+            snapshots=snapshots,
+            manifest_nodes=dict(manifest.nodes),
+            manifest_sources=dict(manifest.sources),
+        )
+
+        # Pick a model that has SQL
+        uid = next(uid for uid, m in models.items() if m.get("compiled_sql"))
+        result = _analyze_single_model(uid, models[uid], schema, resolver, dialect, None)
+
+        assert isinstance(result, _ModelLineageResult)
+        assert result.uid == uid
+        assert not result.skipped
+        assert not result.cached
+
+    def test_skips_model_without_sql(self) -> None:
+        schema: dict[str, dict[str, str]] = {}
+        resolver = TableResolver(models={}, sources={}, seeds={}, snapshots={})
+        result = _analyze_single_model(
+            "test.empty",
+            {"name": "empty"},
+            schema,
+            resolver,
+            None,
+            None,
+        )
+        assert result.skipped
+
+    def test_returns_cache_hit(self) -> None:
+        models, sources, seeds, snapshots, manifest, dialect = _load_test_data()
+        schema = build_schema_mapping(models, sources)
+        resolver = TableResolver(
+            models=models,
+            sources=sources,
+            seeds=seeds,
+            snapshots=snapshots,
+            manifest_nodes=dict(manifest.nodes),
+            manifest_sources=dict(manifest.sources),
+        )
+
+        uid = next(uid for uid, m in models.items() if m.get("compiled_sql"))
+
+        # First call to get the cache entry
+        first = _analyze_single_model(uid, models[uid], schema, resolver, dialect, None)
+
+        # Second call with cached entry
+        second = _analyze_single_model(
+            uid,
+            models[uid],
+            schema,
+            resolver,
+            dialect,
+            first.cache_entry,
+        )
+        assert second.cached
+        assert second.lineage == first.lineage
+
+
+class TestParallelVsSequential:
+    """Verify parallel and sequential produce identical results."""
+
+    def test_results_match(self) -> None:
+        models, sources, seeds, snapshots, manifest, dialect = _load_test_data()
+
+        common_kwargs = dict(
+            models=models,
+            sources=sources,
+            seeds=seeds,
+            snapshots=snapshots,
+            dialect=dialect,
+            manifest_nodes=dict(manifest.nodes),
+            manifest_sources=dict(manifest.sources),
+        )
+
+        sequential = analyze_column_lineage(**common_kwargs, max_workers=1)
+        parallel = analyze_column_lineage(**common_kwargs, max_workers=4)
+
+        assert sequential.keys() == parallel.keys()
+        for uid in sequential:
+            assert sequential[uid].keys() == parallel[uid].keys(), f"Column mismatch for {uid}"
+            for col in sequential[uid]:
+                seq_deps = sorted(str(d) for d in sequential[uid][col])
+                par_deps = sorted(str(d) for d in parallel[uid][col])
+                assert seq_deps == par_deps, f"Dep mismatch {uid}.{col}"
+
+    def test_cache_valid_after_parallel(self, tmp_path: Path) -> None:
+        models, sources, seeds, snapshots, manifest, dialect = _load_test_data()
+        cache_path = tmp_path / ".cache.json"
+
+        analyze_column_lineage(
+            models=models,
+            sources=sources,
+            seeds=seeds,
+            snapshots=snapshots,
+            dialect=dialect,
+            manifest_nodes=dict(manifest.nodes),
+            manifest_sources=dict(manifest.sources),
+            cache_path=cache_path,
+            max_workers=4,
+        )
+
+        assert cache_path.exists()
+        cache = json.loads(cache_path.read_text())
+        assert "__cache_meta__" in cache
+        assert len(cache) > 1  # meta + at least one model

--- a/tests/test_column_lineage_parallel.py
+++ b/tests/test_column_lineage_parallel.py
@@ -52,9 +52,9 @@ class TestComputeDepthWaves:
         }
         waves = _compute_depth_waves(models)
         assert len(waves) == 3
-        assert waves[0] == ["a"]
-        assert waves[1] == ["b"]
-        assert waves[2] == ["c"]
+        assert set(waves[0]) == {"a"}
+        assert set(waves[1]) == {"b"}
+        assert set(waves[2]) == {"c"}
 
     def test_diamond(self) -> None:
         """Diamond: A -> B, A -> C, B -> D, C -> D."""
@@ -66,9 +66,9 @@ class TestComputeDepthWaves:
         }
         waves = _compute_depth_waves(models)
         assert len(waves) == 3
-        assert waves[0] == ["a"]
+        assert set(waves[0]) == {"a"}
         assert set(waves[1]) == {"b", "c"}
-        assert waves[2] == ["d"]
+        assert set(waves[2]) == {"d"}
 
     def test_wide_independent(self) -> None:
         """All independent models should be in one wave."""


### PR DESCRIPTION
## Summary

Closes #71

Column lineage analysis now runs models in parallel using `ProcessPoolExecutor`, bypassing the GIL for true CPU parallelism on SQLGlot parsing.

### Changes
- Extract per-model work into pure function `_analyze_single_model()` with immutable inputs and a result dataclass
- Add `_compute_depth_waves()` for topological DAG ordering of models
- Use `ProcessPoolExecutor` with worker initializer to share schema/resolver across processes without repeated serialization
- Reuse single `ThreadPoolExecutor` per model instead of creating/destroying one per column (eliminates massive overhead)
- Add `--workers` CLI flag (default: `min(8, cpu_count + 4)`, set to 1 for sequential)
- Add benchmark script (`scripts/bench_column_lineage.py`)
- 10 new tests (wave computation, pure function, parallel vs sequential equivalence, cache validity)

### Benchmark (1,870-model Snowflake project)

| | Sequential | Parallel (8 workers) | Speedup |
|---|---|---|---|
| **Total time** | ~5.4 hours (extrapolated) | 96 minutes | **~3.4x** |
| Models analyzed | 1,785 | 1,785 | — |
| Models with lineage | — | 1,444 | — |
| Columns traced | — | 60,180 | — |

### Version bump
Includes version bump to v0.6.0.

## Test plan
- [x] 524 tests passing (514 existing + 10 new)
- [x] Sequential and parallel produce identical results (verified programmatically)
- [x] Cache file valid after parallel run
- [ ] Verify CI passes