### PR TITLE
feat: multi-model lineage selection with pin system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-04-16
+
+### Added
+- **Multi-model lineage selection ("Pin to view")** — pin multiple models to view their combined lineage in one graph. Replaces the single-focus highlightId model with a `pinnedIds` set. (#72)
+- **Pin bar with autocomplete** — search and pin models as color-coded chips above the lineage graph. `×` on a chip unpins it.
+- **dbt selection syntax mode** — `⚡ dbt` toggle accepts dbt-style expressions (`+fct_orders`, `tag:finance`, `stg_*`) and resolves them to pins.
+- **Cmd/Ctrl+Click on graph nodes** — toggle a node's pinned state directly from the lineage graph.
+- **URL-shareable lineage views** — `?pins=id1,id2&depth=3&dir=both` encodes the current selection so views can be shared via link.
+- **Layers filter** — new `Layers` filter dropdown alongside Types/Tags/Folders, with include/exclude modes. Options show colored dots matching the layer bands on the graph. Perfect for isolating a specific dbt layer (e.g. show only "Transform", exclude "Prep"/"Staging").
+- **Empty-state message** on the lineage graph when filters exclude all nodes, with a one-click "Clear all filters" shortcut.
+- **Frontend build scripts** — `npm run sync-static` copies `frontend/dist/` to `src/docglow/static/`, and `npm run build:sync` runs both in one step.
+
+### Changed
+- **Center button** on the lineage graph now fits all pinned models in the viewport (bounding box) rather than a single node.
+- **Union subgraph computation** — lineage is the union of each pinned model's upstream/downstream chain at the current depth.
+
 ## [0.6.1] - 2026-04-15
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,8 @@ mypy src/docglow                # type check
 cd frontend
 npm ci
 npm run build                   # tsc -b && vite build
+npm run sync-static             # copy dist/ → ../src/docglow/static/ (needed before local docglow generate)
+npm run build:sync              # build + sync-static in one step
 npm run test                    # vitest
 npm run test:e2e                # playwright
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "build:sync": "npm run build && npm run sync-static",
+    "sync-static": "rm -rf ../src/docglow/static/assets/* && cp dist/assets/* ../src/docglow/static/assets/ && cp dist/index.html ../src/docglow/static/ && echo 'Synced frontend dist/ → src/docglow/static/'",
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run",

--- a/frontend/src/__tests__/lineageFilters.test.ts
+++ b/frontend/src/__tests__/lineageFilters.test.ts
@@ -135,3 +135,85 @@ describe('computeSubgraphOptions — tag collection', () => {
     expect(options.tags).toEqual(['alpha', 'middle', 'zebra'])
   })
 })
+
+describe('applyFilters — layer filtering', () => {
+  const nodes: LineageNode[] = [
+    makeNode({ id: 'a', layer: 0 }),
+    makeNode({ id: 'b', layer: 1 }),
+    makeNode({ id: 'c', layer: 2 }),
+    makeNode({ id: 'd', layer: 1 }),
+  ]
+  const edges: LineageEdge[] = [
+    makeEdge('a', 'b'),
+    makeEdge('b', 'c'),
+    makeEdge('d', 'c'),
+  ]
+
+  it('returns all nodes when layer filter is empty', () => {
+    const result = applyFilters(nodes, edges, EMPTY_FILTER, EMPTY_FILTER, EMPTY_FILTER, EMPTY_FILTER)
+    expect(result.nodes).toHaveLength(4)
+  })
+
+  it('includes only nodes in selected layers (include mode)', () => {
+    const layerFilter: FilterState = { mode: 'include', selected: new Set(['1']) }
+    const result = applyFilters(nodes, edges, EMPTY_FILTER, EMPTY_FILTER, EMPTY_FILTER, layerFilter)
+    const ids = result.nodes.map(n => n.id).sort()
+    expect(ids).toEqual(['b', 'd'])
+  })
+
+  it('excludes nodes in selected layers (exclude mode)', () => {
+    const layerFilter: FilterState = { mode: 'exclude', selected: new Set(['1']) }
+    const result = applyFilters(nodes, edges, EMPTY_FILTER, EMPTY_FILTER, EMPTY_FILTER, layerFilter)
+    const ids = result.nodes.map(n => n.id).sort()
+    expect(ids).toEqual(['a', 'c'])
+  })
+
+  it('excludes nodes without a layer in include mode', () => {
+    const nodesWithUnassigned = [...nodes, makeNode({ id: 'e' })]
+    const layerFilter: FilterState = { mode: 'include', selected: new Set(['1']) }
+    const result = applyFilters(nodesWithUnassigned, [], EMPTY_FILTER, EMPTY_FILTER, EMPTY_FILTER, layerFilter)
+    expect(result.nodes.map(n => n.id)).not.toContain('e')
+  })
+
+  it('keeps nodes without a layer in exclude mode', () => {
+    const nodesWithUnassigned = [...nodes, makeNode({ id: 'e' })]
+    const layerFilter: FilterState = { mode: 'exclude', selected: new Set(['1']) }
+    const result = applyFilters(nodesWithUnassigned, [], EMPTY_FILTER, EMPTY_FILTER, EMPTY_FILTER, layerFilter)
+    expect(result.nodes.map(n => n.id)).toContain('e')
+  })
+
+  it('also filters edges when layer filter hides endpoints', () => {
+    const layerFilter: FilterState = { mode: 'include', selected: new Set(['1']) }
+    const result = applyFilters(nodes, edges, EMPTY_FILTER, EMPTY_FILTER, EMPTY_FILTER, layerFilter)
+    // Only b and d survive; no edges connect both of them
+    expect(result.edges).toHaveLength(0)
+  })
+})
+
+describe('computeSubgraphOptions — layer collection', () => {
+  it('collects unique layers from nodes', () => {
+    const nodes: LineageNode[] = [
+      makeNode({ id: 'a', layer: 0 }),
+      makeNode({ id: 'b', layer: 1 }),
+      makeNode({ id: 'c', layer: 1 }),
+    ]
+    const options = computeSubgraphOptions(nodes)
+    expect(options.layers).toEqual(['0', '1'])
+  })
+
+  it('returns empty layers when no nodes are assigned', () => {
+    const nodes: LineageNode[] = [makeNode({ id: 'a' }), makeNode({ id: 'b' })]
+    const options = computeSubgraphOptions(nodes)
+    expect(options.layers).toEqual([])
+  })
+
+  it('sorts layers numerically (not lexicographically)', () => {
+    const nodes: LineageNode[] = [
+      makeNode({ id: 'a', layer: 10 }),
+      makeNode({ id: 'b', layer: 2 }),
+      makeNode({ id: 'c', layer: 1 }),
+    ]
+    const options = computeSubgraphOptions(nodes)
+    expect(options.layers).toEqual(['1', '2', '10'])
+  })
+})

--- a/frontend/src/components/lineage/LineageFlow.tsx
+++ b/frontend/src/components/lineage/LineageFlow.tsx
@@ -17,7 +17,7 @@ import '@xyflow/react/dist/style.css'
 import dagre from 'dagre'
 import { useNavigate } from 'react-router-dom'
 import type { LineageNode, LineageEdge, LayerDefinition, ColumnLineageData } from '../../types'
-import { getFullChain } from '../../utils/graphTraversal'
+import { getUnionChain } from '../../utils/graphTraversal'
 import { useColumnHighlightStore } from '../../stores/columnHighlightStore'
 import { buildReverseIndex, getColumnTraceResult } from '../../utils/columnLineageGraph'
 import { DagNode } from './DagNode'
@@ -341,7 +341,8 @@ function computeLayout(
 export interface LineageFlowProps {
   nodes: LineageNode[]
   edges: LineageEdge[]
-  highlightId?: string
+  pinnedIds?: Set<string>
+  onTogglePin?: (id: string) => void
   onNodeClick?: (id: string) => void
   /** Map of folder node id → { modelCount, sourceCount } for folder rendering */
   folderData?: Record<string, { modelCount: number; sourceCount: number }>
@@ -362,7 +363,8 @@ export interface LineageFlowProps {
 function LineageFlowInner({
   nodes,
   edges,
-  highlightId,
+  pinnedIds,
+  onTogglePin: _onTogglePin,
   onNodeClick,
   folderData,
   expandedFolders,
@@ -374,10 +376,6 @@ function LineageFlowInner({
 }: LineageFlowProps) {
   const navigate = useNavigate()
   const { fitView, getNodes } = useReactFlow()
-  // Hover highlighting disabled — it caused flicker when moving rapidly
-  // across nodes. Click-based highlighting (highlightId from sidebar/click)
-  // and the side panel are the proper interaction patterns.
-  const hoveredId: string | null = null
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null)
 
   // Column highlight state
@@ -418,12 +416,12 @@ function LineageFlowInner({
 
   // Hover highlighting disabled — caused flicker when rapidly moving across nodes.
 
-  const centerOnHighlight = useCallback(() => {
-    if (!highlightId) return
-    const target = getNodes().find(n => n.id === highlightId)
-    if (!target) return
-    fitView({ nodes: [target], duration: 300, padding: 0.5 })
-  }, [highlightId, fitView, getNodes])
+  const centerOnPinned = useCallback(() => {
+    if (!pinnedIds || pinnedIds.size === 0) return
+    const targets = getNodes().filter(n => pinnedIds.has(n.id))
+    if (targets.length === 0) return
+    fitView({ nodes: targets, duration: 300, padding: 0.3 })
+  }, [pinnedIds, fitView, getNodes])
 
   const folderNodeIds = useMemo(
     () => new Set(Object.keys(folderData ?? {})),
@@ -462,25 +460,13 @@ function LineageFlowInner({
     [nodes, edges, folderNodeIds, layoutExpandedIds, modelColumns],
   )
 
-  // Highlighting — depth-capped with memoized cache
-  const activeId = hoveredId ?? highlightId ?? null
-  const highlightCacheRef = useRef(new Map<string, Set<string>>())
-  const highlightCacheEdgesRef = useRef(edges)
-
-  // Clear cache when edges change
-  if (highlightCacheEdgesRef.current !== edges) {
-    highlightCacheEdgesRef.current = edges
-    highlightCacheRef.current = new Map()
-  }
+  // Highlighting — depth-capped chain for all pinned nodes
+  const pinnedArray = useMemo(() => Array.from(pinnedIds ?? []), [pinnedIds])
 
   const highlightedSet = useMemo(() => {
-    if (!activeId) return null
-    const cached = highlightCacheRef.current.get(activeId)
-    if (cached) return cached
-    const result = getFullChain(activeId, edges, HIGHLIGHT_DEPTH_CAP)
-    highlightCacheRef.current.set(activeId, result)
-    return result
-  }, [activeId, edges])
+    if (pinnedArray.length === 0) return null
+    return getUnionChain(pinnedArray, edges, HIGHLIGHT_DEPTH_CAP)
+  }, [pinnedArray, edges])
 
   // Compute layer bands from layout positions
   const layerBands = useMemo(() => {
@@ -637,7 +623,7 @@ function LineageFlowInner({
 
       const isFolder = node.type === 'folder'
       const highlighted = !highlightedSet || highlightedSet.has(node.id)
-      const isActiveNode = node.id === activeId
+      const isPinnedNode = pinnedIds?.has(node.id) ?? false
 
       // Only create new objects if something actually changed
       const currentOpacity = (node.style as Record<string, unknown>)?.opacity
@@ -649,7 +635,7 @@ function LineageFlowInner({
         && highlightedSet?.has(node.id)
 
       const styleChanged = currentOpacity !== targetOpacity
-      const dataChanged = currentIsActive !== isActiveNode || currentNoColumnData !== targetNoColumnData
+      const dataChanged = currentIsActive !== isPinnedNode || currentNoColumnData !== targetNoColumnData
 
       if (!styleChanged && !dataChanged && !override) return node
 
@@ -657,14 +643,14 @@ function LineageFlowInner({
         ...node,
         ...(override ? { position: { x: override.x, y: override.y } } : {}),
         ...(dataChanged ? {
-          data: { ...node.data, isActive: isActiveNode, noColumnData: targetNoColumnData },
+          data: { ...node.data, isActive: isPinnedNode, noColumnData: targetNoColumnData },
         } : {}),
         ...(styleChanged ? {
           style: { ...node.style, opacity: targetOpacity },
         } : {}),
       }
     })
-  }, [rfNodes, dragOverrides, highlightedSet, activeId, columnTrace, columnLineageData])
+  }, [rfNodes, dragOverrides, highlightedSet, pinnedIds, columnTrace, columnLineageData])
 
   // Handle node drag changes
   const handleNodesChange = useCallback((changes: NodeChange[]) => {
@@ -880,10 +866,10 @@ function LineageFlowInner({
       maxZoom={3}
     >
       <Controls showInteractive={false}>
-        {highlightId && (
+        {pinnedIds && pinnedIds.size > 0 && (
           <button
-            onClick={centerOnHighlight}
-            title="Center on selected model"
+            onClick={centerOnPinned}
+            title={pinnedIds.size === 1 ? 'Center on pinned model' : `Fit all ${pinnedIds.size} pinned models`}
             className="react-flow__controls-button"
             style={{ color: '#f59e0b' }}
           >

--- a/frontend/src/components/lineage/LineageFlow.tsx
+++ b/frontend/src/components/lineage/LineageFlow.tsx
@@ -799,12 +799,20 @@ function LineageFlowInner({
   }, [])
 
   // Single click → open side panel; double click → navigate to detail page
-  const handleNodeClick: NodeMouseHandler = useCallback((_, node) => {
+  // Cmd/Ctrl+Click → toggle pin
+  const handleNodeClick: NodeMouseHandler = useCallback((event, node) => {
     if (node.id.startsWith('folder:') && onFolderClick) {
       onFolderClick(node.id)
       return
     }
     if (node.id.startsWith('__layer_band_')) return
+
+    // Cmd+Click / Ctrl+Click toggles the pin state
+    if ((event.metaKey || event.ctrlKey) && _onTogglePin) {
+      event.preventDefault()
+      _onTogglePin(node.id)
+      return
+    }
 
     // Use a timer to distinguish single vs double click
     if (clickTimerRef.current) {
@@ -825,7 +833,7 @@ function LineageFlowInner({
         if (onNodeClick) onNodeClick(node.id)
       }, 250)
     }
-  }, [navigate, onNodeClick, onFolderClick, onNavigateAway])
+  }, [navigate, onNodeClick, onFolderClick, onNavigateAway, _onTogglePin])
 
   // Close panel when clicking canvas background
   const handlePaneClick = useCallback(() => {

--- a/frontend/src/components/lineage/PinBar.tsx
+++ b/frontend/src/components/lineage/PinBar.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useCallback } from 'react'
-import type { LineageNode, LineageEdge } from '../../types'
+import type { LineageNode } from '../../types'
 import { resolveDbtSelection } from '../../utils/dbtSelect'
 
 const RESOURCE_COLORS: Record<string, string> = {
@@ -18,10 +18,9 @@ interface PinBarProps {
   onUnpin: (id: string) => void
   onClearAll: () => void
   nodes: LineageNode[]
-  edges: LineageEdge[]
 }
 
-export function PinBar({ pinnedIds, onPin, onPinMany, onUnpin, onClearAll, nodes, edges }: PinBarProps) {
+export function PinBar({ pinnedIds, onPin, onPinMany, onUnpin, onClearAll, nodes }: PinBarProps) {
   const [search, setSearch] = useState('')
   const [isOpen, setIsOpen] = useState(false)
   const [dbtMode, setDbtMode] = useState(false)
@@ -50,7 +49,7 @@ export function PinBar({ pinnedIds, onPin, onPinMany, onUnpin, onClearAll, nodes
 
   const handleDbtSubmit = useCallback(() => {
     if (!search.trim()) return
-    const { matched, errors } = resolveDbtSelection(search, nodes, edges)
+    const { matched, errors } = resolveDbtSelection(search, nodes)
     if (matched.size === 0) {
       setDbtError(errors[0] ?? 'No models matched')
       return
@@ -64,7 +63,7 @@ export function PinBar({ pinnedIds, onPin, onPinMany, onUnpin, onClearAll, nodes
     setSearch('')
     setDbtError(null)
     inputRef.current?.focus()
-  }, [search, nodes, edges, onPin, onPinMany])
+  }, [search, nodes, onPin, onPinMany])
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && dbtMode) {

--- a/frontend/src/components/lineage/PinBar.tsx
+++ b/frontend/src/components/lineage/PinBar.tsx
@@ -1,0 +1,138 @@
+import { useState, useRef, useEffect, useCallback } from 'react'
+import type { LineageNode } from '../../types'
+
+const RESOURCE_COLORS: Record<string, string> = {
+  model: '#2563eb',
+  source: '#16a34a',
+  seed: '#6b7280',
+  snapshot: '#7c3aed',
+  exposure: '#d97706',
+  metric: '#7c3aed',
+}
+
+interface PinBarProps {
+  pinnedIds: Set<string>
+  onPin: (id: string) => void
+  onUnpin: (id: string) => void
+  onClearAll: () => void
+  nodes: LineageNode[]
+}
+
+export function PinBar({ pinnedIds, onPin, onUnpin, onClearAll, nodes }: PinBarProps) {
+  const [search, setSearch] = useState('')
+  const [isOpen, setIsOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const results = search.length >= 1
+    ? nodes
+        .filter(n =>
+          !pinnedIds.has(n.id) &&
+          (n.name.toLowerCase().includes(search.toLowerCase()) ||
+           n.id.toLowerCase().includes(search.toLowerCase()))
+        )
+        .slice(0, 12)
+    : []
+
+  const pinnedNodes = nodes.filter(n => pinnedIds.has(n.id))
+
+  const handleSelect = useCallback((id: string) => {
+    onPin(id)
+    setSearch('')
+    setIsOpen(false)
+    inputRef.current?.focus()
+  }, [onPin])
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Backspace' && search === '' && pinnedNodes.length > 0) {
+      onUnpin(pinnedNodes[pinnedNodes.length - 1].id)
+    }
+    if (e.key === 'Escape') {
+      setSearch('')
+      setIsOpen(false)
+    }
+  }, [search, pinnedNodes, onUnpin])
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setIsOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [])
+
+  return (
+    <div ref={containerRef} className="relative w-full">
+      {/* Input area with chips */}
+      <div
+        className="flex flex-wrap items-center gap-1.5 px-3 py-2 border border-[var(--border)]
+                    rounded-lg bg-[var(--bg)] cursor-text min-h-[40px]"
+        onClick={() => inputRef.current?.focus()}
+      >
+        {pinnedNodes.map(node => (
+          <span
+            key={node.id}
+            className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs font-medium
+                       text-white shrink-0"
+            style={{ backgroundColor: RESOURCE_COLORS[node.resource_type] ?? '#6b7280' }}
+          >
+            {node.name}
+            <button
+              onClick={(e) => { e.stopPropagation(); onUnpin(node.id) }}
+              className="ml-0.5 hover:opacity-70 cursor-pointer"
+            >
+              ×
+            </button>
+          </span>
+        ))}
+        <input
+          ref={inputRef}
+          type="text"
+          value={search}
+          onChange={e => { setSearch(e.target.value); setIsOpen(true) }}
+          onFocus={() => setIsOpen(true)}
+          onKeyDown={handleKeyDown}
+          placeholder={pinnedIds.size === 0 ? 'Search models to pin...' : 'Add another model...'}
+          className="flex-1 min-w-[120px] text-sm bg-transparent outline-none"
+        />
+        {pinnedIds.size >= 2 && (
+          <button
+            onClick={onClearAll}
+            className="text-xs text-[var(--text-muted)] hover:text-[var(--text)] shrink-0 cursor-pointer"
+          >
+            Clear all
+          </button>
+        )}
+      </div>
+
+      {/* Autocomplete dropdown */}
+      {isOpen && results.length > 0 && (
+        <div className="absolute z-50 top-full left-0 right-0 mt-1 border border-[var(--border)]
+                        rounded-lg bg-[var(--bg)] shadow-lg overflow-hidden">
+          <ul className="max-h-60 overflow-y-auto py-1">
+            {results.map(node => (
+              <li key={node.id}>
+                <button
+                  onClick={() => handleSelect(node.id)}
+                  className="w-full text-left px-3 py-1.5 flex items-center gap-2
+                             hover:bg-[var(--bg-surface)] cursor-pointer"
+                >
+                  <span
+                    className="w-2 h-2 rounded-full shrink-0"
+                    style={{ backgroundColor: RESOURCE_COLORS[node.resource_type] ?? '#6b7280' }}
+                  />
+                  <span className="text-sm truncate">{node.name}</span>
+                  <span className="text-xs text-[var(--text-muted)] ml-auto shrink-0">
+                    {node.resource_type}
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/lineage/PinBar.tsx
+++ b/frontend/src/components/lineage/PinBar.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect, useCallback } from 'react'
-import type { LineageNode } from '../../types'
+import type { LineageNode, LineageEdge } from '../../types'
+import { resolveDbtSelection } from '../../utils/dbtSelect'
 
 const RESOURCE_COLORS: Record<string, string> = {
   model: '#2563eb',
@@ -13,18 +14,22 @@ const RESOURCE_COLORS: Record<string, string> = {
 interface PinBarProps {
   pinnedIds: Set<string>
   onPin: (id: string) => void
+  onPinMany?: (ids: string[]) => void
   onUnpin: (id: string) => void
   onClearAll: () => void
   nodes: LineageNode[]
+  edges: LineageEdge[]
 }
 
-export function PinBar({ pinnedIds, onPin, onUnpin, onClearAll, nodes }: PinBarProps) {
+export function PinBar({ pinnedIds, onPin, onPinMany, onUnpin, onClearAll, nodes, edges }: PinBarProps) {
   const [search, setSearch] = useState('')
   const [isOpen, setIsOpen] = useState(false)
+  const [dbtMode, setDbtMode] = useState(false)
+  const [dbtError, setDbtError] = useState<string | null>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
 
-  const results = search.length >= 1
+  const results = !dbtMode && search.length >= 1
     ? nodes
         .filter(n =>
           !pinnedIds.has(n.id) &&
@@ -43,15 +48,47 @@ export function PinBar({ pinnedIds, onPin, onUnpin, onClearAll, nodes }: PinBarP
     inputRef.current?.focus()
   }, [onPin])
 
+  const handleDbtSubmit = useCallback(() => {
+    if (!search.trim()) return
+    const { matched, errors } = resolveDbtSelection(search, nodes, edges)
+    if (matched.size === 0) {
+      setDbtError(errors[0] ?? 'No models matched')
+      return
+    }
+    const ids = Array.from(matched)
+    if (onPinMany) {
+      onPinMany(ids)
+    } else {
+      ids.forEach(id => onPin(id))
+    }
+    setSearch('')
+    setDbtError(null)
+    inputRef.current?.focus()
+  }, [search, nodes, edges, onPin, onPinMany])
+
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && dbtMode) {
+      e.preventDefault()
+      handleDbtSubmit()
+      return
+    }
     if (e.key === 'Backspace' && search === '' && pinnedNodes.length > 0) {
       onUnpin(pinnedNodes[pinnedNodes.length - 1].id)
     }
     if (e.key === 'Escape') {
       setSearch('')
       setIsOpen(false)
+      setDbtError(null)
     }
-  }, [search, pinnedNodes, onUnpin])
+  }, [dbtMode, search, pinnedNodes, onUnpin, handleDbtSubmit])
+
+  const toggleDbtMode = useCallback(() => {
+    setDbtMode(m => !m)
+    setSearch('')
+    setDbtError(null)
+    setIsOpen(false)
+    setTimeout(() => inputRef.current?.focus(), 0)
+  }, [])
 
   useEffect(() => {
     const handler = (e: MouseEvent) => {
@@ -63,12 +100,25 @@ export function PinBar({ pinnedIds, onPin, onUnpin, onClearAll, nodes }: PinBarP
     return () => document.removeEventListener('mousedown', handler)
   }, [])
 
+  // Clear dbt error when user edits input
+  useEffect(() => {
+    if (dbtError) setDbtError(null)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [search])
+
+  const placeholder = dbtMode
+    ? '+fct_orders tag:finance  (dbt selection syntax, press Enter)'
+    : pinnedIds.size === 0
+      ? 'Search models to pin...'
+      : 'Add another model...'
+
   return (
     <div ref={containerRef} className="relative w-full">
       {/* Input area with chips */}
       <div
-        className="flex flex-wrap items-center gap-1.5 px-3 py-2 border border-[var(--border)]
-                    rounded-lg bg-[var(--bg)] cursor-text min-h-[40px]"
+        className={`flex flex-wrap items-center gap-1.5 px-3 py-2 border rounded-lg bg-[var(--bg)] cursor-text min-h-[40px]
+          ${dbtMode ? 'border-amber-500/60' : 'border-[var(--border)]'}
+          ${dbtError ? 'border-red-500/60' : ''}`}
         onClick={() => inputRef.current?.focus()}
       >
         {pinnedNodes.map(node => (
@@ -91,24 +141,42 @@ export function PinBar({ pinnedIds, onPin, onUnpin, onClearAll, nodes }: PinBarP
           ref={inputRef}
           type="text"
           value={search}
-          onChange={e => { setSearch(e.target.value); setIsOpen(true) }}
-          onFocus={() => setIsOpen(true)}
+          onChange={e => { setSearch(e.target.value); if (!dbtMode) setIsOpen(true) }}
+          onFocus={() => { if (!dbtMode) setIsOpen(true) }}
           onKeyDown={handleKeyDown}
-          placeholder={pinnedIds.size === 0 ? 'Search models to pin...' : 'Add another model...'}
-          className="flex-1 min-w-[120px] text-sm bg-transparent outline-none"
+          placeholder={placeholder}
+          className={`flex-1 min-w-[160px] text-sm bg-transparent outline-none
+            ${dbtMode ? 'font-mono' : ''}`}
         />
         {pinnedIds.size >= 2 && (
           <button
-            onClick={onClearAll}
+            onClick={(e) => { e.stopPropagation(); onClearAll() }}
             className="text-xs text-[var(--text-muted)] hover:text-[var(--text)] shrink-0 cursor-pointer"
           >
             Clear all
           </button>
         )}
+        <button
+          onClick={(e) => { e.stopPropagation(); toggleDbtMode() }}
+          title={dbtMode ? 'Switch to search mode' : 'Switch to dbt selection syntax'}
+          className={`shrink-0 px-1.5 py-0.5 rounded text-xs font-medium transition-colors cursor-pointer
+            ${dbtMode
+              ? 'bg-amber-500 text-white'
+              : 'bg-[var(--bg-surface)] text-[var(--text-muted)] hover:text-[var(--text)]'}`}
+        >
+          ⚡ dbt
+        </button>
       </div>
 
+      {/* dbt error */}
+      {dbtError && (
+        <div className="absolute z-50 top-full left-0 right-0 mt-1 px-3 py-2 text-xs text-red-500 bg-red-500/10 border border-red-500/30 rounded-lg">
+          {dbtError}
+        </div>
+      )}
+
       {/* Autocomplete dropdown */}
-      {isOpen && results.length > 0 && (
+      {isOpen && !dbtMode && results.length > 0 && (
         <div className="absolute z-50 top-full left-0 right-0 mt-1 border border-[var(--border)]
                         rounded-lg bg-[var(--bg)] shadow-lg overflow-hidden">
           <ul className="max-h-60 overflow-y-auto py-1">

--- a/frontend/src/components/ui/FilterDropdown.tsx
+++ b/frontend/src/components/ui/FilterDropdown.tsx
@@ -15,6 +15,8 @@ interface FilterDropdownProps {
   onSetMode: (mode: FilterMode) => void
   onClear: () => void
   displayLabel?: (value: string) => string
+  /** Optional per-option accent color (e.g. layer swatch) rendered as a 6px dot. */
+  optionAccent?: (value: string) => string | undefined
 }
 
 export function FilterDropdown({
@@ -25,6 +27,7 @@ export function FilterDropdown({
   onSetMode,
   onClear,
   displayLabel,
+  optionAccent,
 }: FilterDropdownProps) {
   const [open, setOpen] = useState(false)
   const [search, setSearch] = useState('')
@@ -131,30 +134,40 @@ export function FilterDropdown({
             {filtered.length === 0 ? (
               <div className="px-2 py-3 text-xs text-[var(--text-muted)] text-center">No matches</div>
             ) : (
-              filtered.map(option => (
-                <button
-                  key={option}
-                  onClick={() => onToggle(option)}
-                  className="w-full text-left px-2 py-1 text-xs rounded flex items-center gap-2
-                             hover:bg-[var(--bg-surface)] cursor-pointer transition-colors"
-                >
-                  <span className={`w-3.5 h-3.5 rounded border flex items-center justify-center shrink-0
-                    ${filter.selected.has(option)
-                      ? filter.mode === 'include'
-                        ? 'bg-primary border-primary'
-                        : 'bg-warning/80 border-warning'
-                      : 'border-[var(--border)]'
-                    }`}
+              filtered.map(option => {
+                const accent = optionAccent?.(option)
+                return (
+                  <button
+                    key={option}
+                    onClick={() => onToggle(option)}
+                    className="w-full text-left px-2 py-1 text-xs rounded flex items-center gap-2
+                               hover:bg-[var(--bg-surface)] cursor-pointer transition-colors"
                   >
-                    {filter.selected.has(option) && (
-                      <svg width={8} height={8} viewBox="0 0 20 20" fill="white">
-                        <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
-                      </svg>
+                    <span className={`w-3.5 h-3.5 rounded border flex items-center justify-center shrink-0
+                      ${filter.selected.has(option)
+                        ? filter.mode === 'include'
+                          ? 'bg-primary border-primary'
+                          : 'bg-warning/80 border-warning'
+                        : 'border-[var(--border)]'
+                      }`}
+                    >
+                      {filter.selected.has(option) && (
+                        <svg width={8} height={8} viewBox="0 0 20 20" fill="white">
+                          <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                        </svg>
+                      )}
+                    </span>
+                    {accent && (
+                      <span
+                        className="w-1.5 h-1.5 rounded-full shrink-0"
+                        style={{ backgroundColor: accent }}
+                        aria-hidden
+                      />
                     )}
-                  </span>
-                  <span className="truncate text-[var(--text)]">{getLabel(option)}</span>
-                </button>
-              ))
+                    <span className="truncate text-[var(--text)]">{getLabel(option)}</span>
+                  </button>
+                )
+              })
             )}
           </div>
 

--- a/frontend/src/pages/LineagePage.tsx
+++ b/frontend/src/pages/LineagePage.tsx
@@ -2,8 +2,9 @@ import { useState, useMemo, useCallback, useRef, useEffect } from 'react'
 import { useProjectStore } from '../stores/projectStore'
 import { useTagFilterStore } from '../stores/tagFilterStore'
 import { LineageFlow } from '../components/lineage/LineageFlow'
+import { PinBar } from '../components/lineage/PinBar'
 import { FilterDropdown } from '../components/ui/FilterDropdown'
-import { getSubgraph } from '../utils/graph'
+import { getUnionSubgraph } from '../utils/graph'
 import { applyFilters, useFilterState, computeSubgraphOptions, RESOURCE_TYPES } from '../utils/lineageFilters'
 import type { FilterState } from '../components/ui/FilterDropdown'
 import type { LineageDirection } from '../utils/graph'
@@ -40,7 +41,7 @@ function computeSuggestions(nodes: LineageNode[], edges: LineageEdge[]): ModelSu
 
 export function LineagePage() {
   const { data } = useProjectStore()
-  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null)
+  const [pinnedIds, setPinnedIds] = useState<Set<string>>(new Set())
   const [depth, setDepth] = useState(2)
   const [direction, setDirection] = useState<LineageDirection>('both')
   const [search, setSearch] = useState('')
@@ -66,11 +67,33 @@ export function LineagePage() {
       .slice(0, 20)
   }, [data, search])
 
-  // Compute raw subgraph once, then derive filtered view and filter options from it
+  const handlePin = useCallback((id: string) => {
+    setPinnedIds(prev => new Set([...prev, id]))
+    setSearch('')
+  }, [])
+
+  const handleUnpin = useCallback((id: string) => {
+    setPinnedIds(prev => {
+      const next = new Set(prev)
+      next.delete(id)
+      return next
+    })
+  }, [])
+
+  const handleClearAll = useCallback(() => {
+    setPinnedIds(new Set())
+    setSearch('')
+    clearTypes()
+    clearFolders()
+  }, [clearTypes, clearFolders])
+
+  // Compute union subgraph for all pinned models
+  const pinnedArray = useMemo(() => Array.from(pinnedIds), [pinnedIds])
+
   const rawSubgraph = useMemo(() => {
-    if (!data || !selectedNodeId) return null
-    return getSubgraph(selectedNodeId, data.lineage.nodes, data.lineage.edges, depth, direction)
-  }, [data, selectedNodeId, depth, direction])
+    if (!data || pinnedIds.size === 0) return null
+    return getUnionSubgraph(pinnedArray, data.lineage.nodes, data.lineage.edges, depth, direction)
+  }, [data, pinnedArray, depth, direction])
 
   const subgraph = useMemo(() => {
     if (!rawSubgraph) return null
@@ -82,27 +105,10 @@ export function LineagePage() {
     return computeSubgraphOptions(rawSubgraph.nodes)
   }, [rawSubgraph])
 
-  const selectedNode = useMemo(() => {
-    if (!data || !selectedNodeId) return null
-    return data.lineage.nodes.find(n => n.id === selectedNodeId) ?? null
-  }, [data, selectedNodeId])
-
   const modelColumnsMap = useMemo(() => {
     if (!data) return {}
     return buildModelColumnsMap(data)
   }, [data])
-
-  const handleSelectModel = useCallback((id: string) => {
-    setSelectedNodeId(id)
-    setSearch('')
-  }, [])
-
-  const handleClearSelection = useCallback(() => {
-    setSelectedNodeId(null)
-    setSearch('')
-    clearTypes()
-    clearFolders()
-  }, [clearTypes, clearFolders])
 
   // Column search state
   const [colSearch, setColSearch] = useState('')
@@ -124,7 +130,6 @@ export function LineagePage() {
         }
       }
     }
-    // Also check columns that are referenced as sources (not just targets)
     for (const [, columns] of Object.entries(data.column_lineage)) {
       for (const deps of Object.values(columns)) {
         for (const dep of deps) {
@@ -153,7 +158,6 @@ export function LineagePage() {
     setColSearchOpen(false)
   }, [clearSelection])
 
-  // Close dropdown on outside click
   useEffect(() => {
     const handler = (e: MouseEvent) => {
       if (colSearchRef.current && !colSearchRef.current.contains(e.target as Node)) {
@@ -174,165 +178,177 @@ export function LineagePage() {
 
   if (!data) return null
 
-  // Exploring a model's lineage
-  if (selectedNodeId && subgraph) {
+  // Exploring pinned models' lineage
+  if (pinnedIds.size > 0 && subgraph) {
     return (
       <div className="h-full flex flex-col">
-        <div className="flex items-center gap-3 mb-2 shrink-0 flex-wrap">
-          <button
-            onClick={handleClearSelection}
-            className="p-1 rounded hover:bg-[var(--bg-surface)] cursor-pointer transition-colors text-[var(--text-muted)]"
-            title="Back to overview"
-          >
-            <svg width={20} height={20} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
-              <path d="M19 12H5M12 19l-7-7 7-7" />
-            </svg>
-          </button>
-          <div className="mr-2">
-            <h1 className="text-lg font-bold leading-tight">{selectedNode?.name ?? selectedNodeId}</h1>
-            <span className="text-xs text-[var(--text-muted)]">{selectedNode?.folder}</span>
-          </div>
-
+        <div className="flex flex-col gap-2 mb-2 shrink-0">
+          {/* Pin bar */}
           <div className="flex items-center gap-2">
-            <label className="text-xs text-[var(--text-muted)]">Depth</label>
-            <input
-              type="range"
-              min={1}
-              max={6}
-              value={depth}
-              onChange={e => setDepth(Number(e.target.value))}
-              className="w-20 accent-[var(--primary)]"
-            />
-            <span className="text-xs font-medium w-4 text-center">{depth}</span>
-          </div>
-
-          <div className="h-4 w-px bg-[var(--border)]" />
-
-          {/* Direction toggle */}
-          <div className="flex items-center rounded overflow-hidden border border-[var(--border)]">
-            {(['upstream', 'both', 'downstream'] as const).map(dir => (
-              <button
-                key={dir}
-                onClick={() => setDirection(dir)}
-                className={`px-2 py-0.5 text-xs cursor-pointer transition-colors flex items-center gap-1
-                  ${direction === dir
-                    ? 'bg-primary text-white'
-                    : 'bg-[var(--bg)] text-[var(--text-muted)] hover:text-[var(--text)] hover:bg-[var(--bg-surface)]'
-                  }`}
-                title={dir === 'both' ? 'Show upstream & downstream' : `Show ${dir} only`}
-              >
-                {dir === 'upstream' && (
-                  <svg width={10} height={10} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5}>
-                    <path d="M19 12H5M12 5l-7 7" />
-                  </svg>
-                )}
-                {dir === 'both' && (
-                  <svg width={10} height={10} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5}>
-                    <path d="M5 12h14M8 8l-4 4 4 4M16 8l4 4-4 4" />
-                  </svg>
-                )}
-                {dir === 'downstream' && (
-                  <svg width={10} height={10} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5}>
-                    <path d="M5 12h14M12 5l7 7" />
-                  </svg>
-                )}
-                {dir === 'upstream' ? 'Up' : dir === 'downstream' ? 'Down' : 'Both'}
-              </button>
-            ))}
-          </div>
-
-          <div className="h-4 w-px bg-[var(--border)]" />
-
-          <FilterDropdown
-            label="Types"
-            options={subgraphOptions.types}
-            filter={typeFilter}
-            onToggle={toggleType}
-            onSetMode={setTypeMode}
-            onClear={clearTypes}
-          />
-          {subgraphOptions.tags.length > 0 && (
-            <FilterDropdown
-              label="Tags"
-              options={subgraphOptions.tags}
-              filter={tagFilter}
-              onToggle={toggleTag}
-              onSetMode={setTagMode}
-              onClear={clearTags}
-            />
-          )}
-          {subgraphOptions.folders.length > 0 && (
-            <FilterDropdown
-              label="Folders"
-              options={subgraphOptions.folders}
-              filter={folderFilter}
-              onToggle={toggleFolder}
-              onSetMode={setFolderMode}
-              onClear={clearFolders}
-              displayLabel={(v) => v.split('/').pop() ?? v}
-            />
-          )}
-
-          {hasActiveFilters && (
             <button
-              onClick={clearAllFilters}
-              className="px-2 py-1 text-xs rounded bg-danger/10 text-danger hover:bg-danger/20 cursor-pointer transition-colors"
+              onClick={handleClearAll}
+              className="p-1 rounded hover:bg-[var(--bg-surface)] cursor-pointer transition-colors text-[var(--text-muted)] shrink-0"
+              title="Back to overview"
             >
-              Clear filters
+              <svg width={20} height={20} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+                <path d="M19 12H5M12 19l-7-7 7-7" />
+              </svg>
             </button>
-          )}
+            <div className="flex-1">
+              <PinBar
+                pinnedIds={pinnedIds}
+                onPin={handlePin}
+                onUnpin={handleUnpin}
+                onClearAll={handleClearAll}
+                nodes={data.lineage.nodes}
+              />
+            </div>
+          </div>
 
-          {/* Column search */}
-          {data.column_lineage && (
-            <>
-              <div className="h-4 w-px bg-[var(--border)]" />
-              <div className="relative" ref={colSearchRef}>
-                <input
-                  type="text"
-                  value={colSearch}
-                  onChange={e => { setColSearch(e.target.value); setColSearchOpen(true) }}
-                  onFocus={() => setColSearchOpen(true)}
-                  placeholder="Search column..."
-                  className="w-36 px-2 py-0.5 text-xs border border-[var(--border)] rounded bg-[var(--bg)] outline-none focus:border-primary transition-colors"
-                />
-                {colSearch && (
-                  <button
-                    onClick={handleColSearchClear}
-                    className="absolute right-1.5 top-1/2 -translate-y-1/2 text-[var(--text-muted)] hover:text-[var(--text)] cursor-pointer"
-                  >
+          {/* Controls row */}
+          <div className="flex items-center gap-2 flex-wrap">
+            <div className="flex items-center gap-2">
+              <label className="text-xs text-[var(--text-muted)]">Depth</label>
+              <input
+                type="range"
+                min={1}
+                max={6}
+                value={depth}
+                onChange={e => setDepth(Number(e.target.value))}
+                className="w-20 accent-[var(--primary)]"
+              />
+              <span className="text-xs font-medium w-4 text-center">{depth}</span>
+            </div>
+
+            <div className="h-4 w-px bg-[var(--border)]" />
+
+            {/* Direction toggle */}
+            <div className="flex items-center rounded overflow-hidden border border-[var(--border)]">
+              {(['upstream', 'both', 'downstream'] as const).map(dir => (
+                <button
+                  key={dir}
+                  onClick={() => setDirection(dir)}
+                  className={`px-2 py-0.5 text-xs cursor-pointer transition-colors flex items-center gap-1
+                    ${direction === dir
+                      ? 'bg-primary text-white'
+                      : 'bg-[var(--bg)] text-[var(--text-muted)] hover:text-[var(--text)] hover:bg-[var(--bg-surface)]'
+                    }`}
+                  title={dir === 'both' ? 'Show upstream & downstream' : `Show ${dir} only`}
+                >
+                  {dir === 'upstream' && (
                     <svg width={10} height={10} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5}>
-                      <path d="M18 6 6 18M6 6l12 12" />
+                      <path d="M19 12H5M12 5l-7 7" />
                     </svg>
-                  </button>
-                )}
-                {colSearchOpen && colSearchResults.length > 0 && (
-                  <div className="absolute top-full left-0 mt-1 z-50 bg-[var(--bg)] border border-[var(--border)] rounded-lg shadow-lg max-h-48 overflow-y-auto min-w-[240px]">
-                    {colSearchResults.map((r, i) => (
-                      <button
-                        key={`${r.modelId}-${r.columnName}-${i}`}
-                        onClick={() => handleColSearchSelect(r.modelId, r.columnName)}
-                        className="w-full text-left px-3 py-1.5 text-xs hover:bg-[var(--bg-surface)] cursor-pointer transition-colors"
-                      >
-                        <span className="font-medium text-[var(--text)]">{r.columnName}</span>
-                        <span className="text-[var(--text-muted)] ml-1.5">in {r.modelName}</span>
-                      </button>
-                    ))}
-                  </div>
-                )}
-              </div>
-            </>
-          )}
+                  )}
+                  {dir === 'both' && (
+                    <svg width={10} height={10} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5}>
+                      <path d="M5 12h14M8 8l-4 4 4 4M16 8l4 4-4 4" />
+                    </svg>
+                  )}
+                  {dir === 'downstream' && (
+                    <svg width={10} height={10} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5}>
+                      <path d="M5 12h14M12 5l7 7" />
+                    </svg>
+                  )}
+                  {dir === 'upstream' ? 'Up' : dir === 'downstream' ? 'Down' : 'Both'}
+                </button>
+              ))}
+            </div>
 
-          <span className="text-xs text-[var(--text-muted)] ml-auto">
-            {subgraph.nodes.length} nodes · {subgraph.edges.length} edges
-          </span>
+            <div className="h-4 w-px bg-[var(--border)]" />
+
+            <FilterDropdown
+              label="Types"
+              options={subgraphOptions.types}
+              filter={typeFilter}
+              onToggle={toggleType}
+              onSetMode={setTypeMode}
+              onClear={clearTypes}
+            />
+            {subgraphOptions.tags.length > 0 && (
+              <FilterDropdown
+                label="Tags"
+                options={subgraphOptions.tags}
+                filter={tagFilter}
+                onToggle={toggleTag}
+                onSetMode={setTagMode}
+                onClear={clearTags}
+              />
+            )}
+            {subgraphOptions.folders.length > 0 && (
+              <FilterDropdown
+                label="Folders"
+                options={subgraphOptions.folders}
+                filter={folderFilter}
+                onToggle={toggleFolder}
+                onSetMode={setFolderMode}
+                onClear={clearFolders}
+                displayLabel={(v) => v.split('/').pop() ?? v}
+              />
+            )}
+
+            {hasActiveFilters && (
+              <button
+                onClick={clearAllFilters}
+                className="px-2 py-1 text-xs rounded bg-danger/10 text-danger hover:bg-danger/20 cursor-pointer transition-colors"
+              >
+                Clear filters
+              </button>
+            )}
+
+            {/* Column search */}
+            {data.column_lineage && (
+              <>
+                <div className="h-4 w-px bg-[var(--border)]" />
+                <div className="relative" ref={colSearchRef}>
+                  <input
+                    type="text"
+                    value={colSearch}
+                    onChange={e => { setColSearch(e.target.value); setColSearchOpen(true) }}
+                    onFocus={() => setColSearchOpen(true)}
+                    placeholder="Search column..."
+                    className="w-36 px-2 py-0.5 text-xs border border-[var(--border)] rounded bg-[var(--bg)] outline-none focus:border-primary transition-colors"
+                  />
+                  {colSearch && (
+                    <button
+                      onClick={handleColSearchClear}
+                      className="absolute right-1.5 top-1/2 -translate-y-1/2 text-[var(--text-muted)] hover:text-[var(--text)] cursor-pointer"
+                    >
+                      <svg width={10} height={10} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5}>
+                        <path d="M18 6 6 18M6 6l12 12" />
+                      </svg>
+                    </button>
+                  )}
+                  {colSearchOpen && colSearchResults.length > 0 && (
+                    <div className="absolute top-full left-0 mt-1 z-50 bg-[var(--bg)] border border-[var(--border)] rounded-lg shadow-lg max-h-48 overflow-y-auto min-w-[240px]">
+                      {colSearchResults.map((r, i) => (
+                        <button
+                          key={`${r.modelId}-${r.columnName}-${i}`}
+                          onClick={() => handleColSearchSelect(r.modelId, r.columnName)}
+                          className="w-full text-left px-3 py-1.5 text-xs hover:bg-[var(--bg-surface)] cursor-pointer transition-colors"
+                        >
+                          <span className="font-medium text-[var(--text)]">{r.columnName}</span>
+                          <span className="text-[var(--text-muted)] ml-1.5">in {r.modelName}</span>
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </>
+            )}
+
+            <span className="text-xs text-[var(--text-muted)] ml-auto">
+              {subgraph.nodes.length} nodes · {subgraph.edges.length} edges
+            </span>
+          </div>
         </div>
 
         <div className="flex-1 relative min-h-0">
           <LineageFlow
             nodes={subgraph.nodes}
             edges={subgraph.edges}
-            highlightId={selectedNodeId}
+            pinnedIds={pinnedIds}
+            onTogglePin={handlePin}
             layerConfig={data.lineage.layer_config}
             columnLineageData={data.column_lineage}
             modelColumns={modelColumnsMap}
@@ -351,7 +367,7 @@ export function LineagePage() {
         <div className="max-w-3xl mx-auto py-8 px-4">
           <h1 className="text-2xl font-bold mb-1">Lineage Explorer</h1>
           <p className="text-sm text-[var(--text-muted)] mb-6">
-            Select a model to explore its upstream and downstream dependencies.
+            Search for models to pin them to the lineage view. Pin multiple models to see their combined lineage.
           </p>
 
           {/* Search */}
@@ -388,7 +404,7 @@ export function LineagePage() {
                   searchResults.map(node => (
                     <button
                       key={node.id}
-                      onClick={() => handleSelectModel(node.id)}
+                      onClick={() => handlePin(node.id)}
                       className="w-full text-left px-4 py-2 text-sm hover:bg-[var(--bg-surface)]
                                  cursor-pointer transition-colors flex items-center justify-between"
                     >
@@ -419,7 +435,7 @@ export function LineagePage() {
                 {suggestions.map(s => (
                   <button
                     key={s.node.id}
-                    onClick={() => handleSelectModel(s.node.id)}
+                    onClick={() => handlePin(s.node.id)}
                     className="text-left p-3 rounded-lg border border-[var(--border)] bg-[var(--bg-surface)]
                                hover:border-primary/50 cursor-pointer transition-colors group"
                   >

--- a/frontend/src/pages/LineagePage.tsx
+++ b/frontend/src/pages/LineagePage.tsx
@@ -250,7 +250,6 @@ export function LineagePage() {
                 onUnpin={handleUnpin}
                 onClearAll={handleClearAll}
                 nodes={data.lineage.nodes}
-                edges={data.lineage.edges}
               />
             </div>
           </div>

--- a/frontend/src/pages/LineagePage.tsx
+++ b/frontend/src/pages/LineagePage.tsx
@@ -80,6 +80,7 @@ export function LineagePage() {
   const { selected: globalTagSelected, mode: globalTagMode, toggle: toggleTag, setMode: setTagMode, clear: clearTags } = useTagFilterStore()
   const tagFilter: FilterState = useMemo(() => ({ mode: globalTagMode, selected: new Set(globalTagSelected) }), [globalTagSelected, globalTagMode])
   const [folderFilter, toggleFolder, setFolderMode, clearFolders] = useFilterState()
+  const [layerFilter, toggleLayer, setLayerMode, clearLayers] = useFilterState()
 
   const suggestions = useMemo(() => {
     if (!data) return []
@@ -145,13 +146,22 @@ export function LineagePage() {
 
   const subgraph = useMemo(() => {
     if (!rawSubgraph) return null
-    return applyFilters(rawSubgraph.nodes, rawSubgraph.edges, typeFilter, tagFilter, folderFilter)
-  }, [rawSubgraph, typeFilter, tagFilter, folderFilter])
+    return applyFilters(rawSubgraph.nodes, rawSubgraph.edges, typeFilter, tagFilter, folderFilter, layerFilter)
+  }, [rawSubgraph, typeFilter, tagFilter, folderFilter, layerFilter])
 
   const subgraphOptions = useMemo(() => {
-    if (!rawSubgraph) return { tags: [], folders: [], types: RESOURCE_TYPES }
+    if (!rawSubgraph) return { tags: [], folders: [], types: RESOURCE_TYPES, layers: [] as string[] }
     return computeSubgraphOptions(rawSubgraph.nodes)
   }, [rawSubgraph])
+
+  // Map layer rank → definition for display labels and accent colors
+  const layerByRank = useMemo(() => {
+    const map = new Map<string, { name: string; color: string }>()
+    for (const l of data?.lineage.layer_config ?? []) {
+      map.set(String(l.rank), { name: l.name, color: l.color })
+    }
+    return map
+  }, [data])
 
   const modelColumnsMap = useMemo(() => {
     if (!data) return {}
@@ -216,13 +226,14 @@ export function LineagePage() {
     return () => document.removeEventListener('mousedown', handler)
   }, [])
 
-  const hasActiveFilters = typeFilter.selected.size > 0 || tagFilter.selected.size > 0 || folderFilter.selected.size > 0
+  const hasActiveFilters = typeFilter.selected.size > 0 || tagFilter.selected.size > 0 || folderFilter.selected.size > 0 || layerFilter.selected.size > 0
 
   const clearAllFilters = useCallback(() => {
     clearTypes()
     clearTags()
     clearFolders()
-  }, [clearTypes, clearTags, clearFolders])
+    clearLayers()
+  }, [clearTypes, clearTags, clearFolders, clearLayers])
 
   if (!data) return null
 
@@ -335,6 +346,18 @@ export function LineagePage() {
                 displayLabel={(v) => v.split('/').pop() ?? v}
               />
             )}
+            {subgraphOptions.layers.length > 0 && (
+              <FilterDropdown
+                label="Layers"
+                options={subgraphOptions.layers}
+                filter={layerFilter}
+                onToggle={toggleLayer}
+                onSetMode={setLayerMode}
+                onClear={clearLayers}
+                displayLabel={(rank) => layerByRank.get(rank)?.name ?? `Layer ${rank}`}
+                optionAccent={(rank) => layerByRank.get(rank)?.color}
+              />
+            )}
 
             {hasActiveFilters && (
               <button
@@ -393,15 +416,36 @@ export function LineagePage() {
         </div>
 
         <div className="flex-1 relative min-h-0">
-          <LineageFlow
-            nodes={subgraph.nodes}
-            edges={subgraph.edges}
-            pinnedIds={pinnedIds}
-            onTogglePin={handleTogglePin}
-            layerConfig={data.lineage.layer_config}
-            columnLineageData={data.column_lineage}
-            modelColumns={modelColumnsMap}
-          />
+          {subgraph.nodes.length === 0 ? (
+            <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 text-center px-6">
+              <svg width={32} height={32} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} className="text-[var(--text-muted)]">
+                <circle cx={11} cy={11} r={8} />
+                <path d="m21 21-4.35-4.35" />
+                <path d="M8 11h6" />
+              </svg>
+              <div>
+                <div className="text-sm font-medium text-[var(--text)]">No models match the filter criteria.</div>
+                {hasActiveFilters && (
+                  <button
+                    onClick={clearAllFilters}
+                    className="mt-2 text-xs text-primary hover:underline cursor-pointer"
+                  >
+                    Clear all filters
+                  </button>
+                )}
+              </div>
+            </div>
+          ) : (
+            <LineageFlow
+              nodes={subgraph.nodes}
+              edges={subgraph.edges}
+              pinnedIds={pinnedIds}
+              onTogglePin={handleTogglePin}
+              layerConfig={data.lineage.layer_config}
+              columnLineageData={data.column_lineage}
+              modelColumns={modelColumnsMap}
+            />
+          )}
         </div>
       </div>
     )

--- a/frontend/src/pages/LineagePage.tsx
+++ b/frontend/src/pages/LineagePage.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useCallback, useRef, useEffect } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import { useProjectStore } from '../stores/projectStore'
 import { useTagFilterStore } from '../stores/tagFilterStore'
 import { LineageFlow } from '../components/lineage/LineageFlow'
@@ -41,10 +42,39 @@ function computeSuggestions(nodes: LineageNode[], edges: LineageEdge[]): ModelSu
 
 export function LineagePage() {
   const { data } = useProjectStore()
-  const [pinnedIds, setPinnedIds] = useState<Set<string>>(new Set())
-  const [depth, setDepth] = useState(2)
-  const [direction, setDirection] = useState<LineageDirection>('both')
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  // Initialize pins from URL on first render
+  const [pinnedIds, setPinnedIds] = useState<Set<string>>(() => {
+    const raw = searchParams.get('pins')
+    return raw ? new Set(raw.split(',').filter(Boolean)) : new Set()
+  })
+  const [depth, setDepth] = useState(() => {
+    const raw = searchParams.get('depth')
+    const n = raw ? parseInt(raw, 10) : 2
+    return isNaN(n) ? 2 : Math.max(1, Math.min(6, n))
+  })
+  const [direction, setDirection] = useState<LineageDirection>(() => {
+    const raw = searchParams.get('dir')
+    return raw === 'upstream' || raw === 'downstream' ? raw : 'both'
+  })
   const [search, setSearch] = useState('')
+
+  // Sync state → URL
+  useEffect(() => {
+    const params = new URLSearchParams(searchParams)
+    if (pinnedIds.size > 0) {
+      params.set('pins', Array.from(pinnedIds).join(','))
+      params.set('depth', String(depth))
+      params.set('dir', direction)
+    } else {
+      params.delete('pins')
+      params.delete('depth')
+      params.delete('dir')
+    }
+    setSearchParams(params, { replace: true })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pinnedIds, depth, direction])
 
   const [typeFilter, toggleType, setTypeMode, clearTypes] = useFilterState()
   const { selected: globalTagSelected, mode: globalTagMode, toggle: toggleTag, setMode: setTagMode, clear: clearTags } = useTagFilterStore()
@@ -72,10 +102,28 @@ export function LineagePage() {
     setSearch('')
   }, [])
 
+  const handlePinMany = useCallback((ids: string[]) => {
+    setPinnedIds(prev => {
+      const next = new Set(prev)
+      for (const id of ids) next.add(id)
+      return next
+    })
+    setSearch('')
+  }, [])
+
   const handleUnpin = useCallback((id: string) => {
     setPinnedIds(prev => {
       const next = new Set(prev)
       next.delete(id)
+      return next
+    })
+  }, [])
+
+  const handleTogglePin = useCallback((id: string) => {
+    setPinnedIds(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
       return next
     })
   }, [])
@@ -198,9 +246,11 @@ export function LineagePage() {
               <PinBar
                 pinnedIds={pinnedIds}
                 onPin={handlePin}
+                onPinMany={handlePinMany}
                 onUnpin={handleUnpin}
                 onClearAll={handleClearAll}
                 nodes={data.lineage.nodes}
+                edges={data.lineage.edges}
               />
             </div>
           </div>
@@ -348,7 +398,7 @@ export function LineagePage() {
             nodes={subgraph.nodes}
             edges={subgraph.edges}
             pinnedIds={pinnedIds}
-            onTogglePin={handlePin}
+            onTogglePin={handleTogglePin}
             layerConfig={data.lineage.layer_config}
             columnLineageData={data.column_lineage}
             modelColumns={modelColumnsMap}

--- a/frontend/src/pages/ModelPage.tsx
+++ b/frontend/src/pages/ModelPage.tsx
@@ -426,7 +426,7 @@ export function ModelPage() {
             <LineageFlow
               nodes={filteredSubgraph.nodes}
               edges={filteredSubgraph.edges}
-              highlightId={decodedId}
+              pinnedIds={new Set([decodedId])}
               layerConfig={data?.lineage.layer_config}
               onNavigateAway={() => setLineageFullscreen(false)}
               columnLineageData={data?.column_lineage}

--- a/frontend/src/utils/dbtSelect.ts
+++ b/frontend/src/utils/dbtSelect.ts
@@ -1,21 +1,26 @@
 /**
- * Parse dbt model selection syntax and resolve to a set of model unique_ids.
+ * Parse dbt model selection syntax and resolve to a set of model unique_ids
+ * that should be pinned.
  *
  * Supported syntax:
  *   model_name          — pin that model
- *   +model_name         — pin model + all upstream
- *   model_name+         — pin model + all downstream
- *   +model_name+        — pin model + upstream + downstream
+ *   +model_name         — pin that model (upstream shown via graph lineage)
+ *   model_name+         — pin that model (downstream shown via graph lineage)
+ *   +model_name+        — pin that model (both shown via graph lineage)
  *   tag:finance         — pin all models with that tag
- *   stg_*               — glob pattern on model name
- *   fct_*+              — glob with downstream expansion
+ *   stg_*               — glob pattern, pins all matching models
  *
  * Space-separated expressions are unioned:
- *   "+fct_orders +dim_customers tag:finance"
+ *   "+fct_orders dim_customers tag:finance"
+ *
+ * Note: the +/+ markers are accepted for dbt familiarity but do NOT
+ * expand upstream/downstream into separate pins. The pin system's
+ * depth/direction controls already handle lineage expansion on the graph.
+ * This avoids polluting the pin bar with hundreds of chips for a single
+ * `+fct_orders` expression.
  */
 
-import type { LineageNode, LineageEdge } from '../types'
-import { getUpstream, getDownstream } from './graphTraversal'
+import type { LineageNode } from '../types'
 
 export interface DbtSelectResult {
   matched: Set<string>
@@ -67,7 +72,6 @@ function matchToken(
 export function resolveDbtSelection(
   expression: string,
   nodes: LineageNode[],
-  edges: LineageEdge[],
 ): DbtSelectResult {
   const matched = new Set<string>()
   const errors: string[] = []
@@ -76,11 +80,10 @@ export function resolveDbtSelection(
   const tokens = expression.trim().split(/\s+/).filter(Boolean)
 
   for (const rawToken of tokens) {
+    // Strip +/+ markers — accepted for dbt familiarity but don't expand pins
     let token = rawToken
-    const upstream = token.startsWith('+')
-    if (upstream) token = token.slice(1)
-    const downstream = token.endsWith('+')
-    if (downstream) token = token.slice(0, -1)
+    if (token.startsWith('+')) token = token.slice(1)
+    if (token.endsWith('+')) token = token.slice(0, -1)
 
     if (!token) {
       errors.push(`Empty selector in "${rawToken}"`)
@@ -93,15 +96,7 @@ export function resolveDbtSelection(
       continue
     }
 
-    for (const id of hits) {
-      matched.add(id)
-      if (upstream) {
-        for (const u of getUpstream(id, edges)) matched.add(u)
-      }
-      if (downstream) {
-        for (const d of getDownstream(id, edges)) matched.add(d)
-      }
-    }
+    for (const id of hits) matched.add(id)
   }
 
   return { matched, errors }

--- a/frontend/src/utils/dbtSelect.ts
+++ b/frontend/src/utils/dbtSelect.ts
@@ -1,0 +1,108 @@
+/**
+ * Parse dbt model selection syntax and resolve to a set of model unique_ids.
+ *
+ * Supported syntax:
+ *   model_name          — pin that model
+ *   +model_name         — pin model + all upstream
+ *   model_name+         — pin model + all downstream
+ *   +model_name+        — pin model + upstream + downstream
+ *   tag:finance         — pin all models with that tag
+ *   stg_*               — glob pattern on model name
+ *   fct_*+              — glob with downstream expansion
+ *
+ * Space-separated expressions are unioned:
+ *   "+fct_orders +dim_customers tag:finance"
+ */
+
+import type { LineageNode, LineageEdge } from '../types'
+import { getUpstream, getDownstream } from './graphTraversal'
+
+export interface DbtSelectResult {
+  matched: Set<string>
+  errors: string[]
+}
+
+function globToRegex(pattern: string): RegExp {
+  // Escape regex specials except * which we translate to .*
+  const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*')
+  return new RegExp(`^${escaped}$`, 'i')
+}
+
+function isGlob(s: string): boolean {
+  return s.includes('*')
+}
+
+/** Find nodes matching a single selector token (without +/+ markers). */
+function matchToken(
+  token: string,
+  nodes: LineageNode[],
+  nodesById: Map<string, LineageNode>,
+): string[] {
+  // tag:xyz
+  if (token.startsWith('tag:')) {
+    const tag = token.slice(4).toLowerCase()
+    return nodes
+      .filter(n => (n.tags ?? []).some(t => t.toLowerCase() === tag))
+      .map(n => n.id)
+  }
+
+  // glob pattern
+  if (isGlob(token)) {
+    const regex = globToRegex(token)
+    return nodes.filter(n => regex.test(n.name)).map(n => n.id)
+  }
+
+  // exact unique_id match
+  if (nodesById.has(token)) return [token]
+
+  // exact name match
+  const byName = nodes.filter(n => n.name === token)
+  if (byName.length > 0) return byName.map(n => n.id)
+
+  // case-insensitive name match (last resort)
+  const byNameCi = nodes.filter(n => n.name.toLowerCase() === token.toLowerCase())
+  return byNameCi.map(n => n.id)
+}
+
+export function resolveDbtSelection(
+  expression: string,
+  nodes: LineageNode[],
+  edges: LineageEdge[],
+): DbtSelectResult {
+  const matched = new Set<string>()
+  const errors: string[] = []
+  const nodesById = new Map(nodes.map(n => [n.id, n]))
+
+  const tokens = expression.trim().split(/\s+/).filter(Boolean)
+
+  for (const rawToken of tokens) {
+    let token = rawToken
+    const upstream = token.startsWith('+')
+    if (upstream) token = token.slice(1)
+    const downstream = token.endsWith('+')
+    if (downstream) token = token.slice(0, -1)
+
+    if (!token) {
+      errors.push(`Empty selector in "${rawToken}"`)
+      continue
+    }
+
+    const hits = matchToken(token, nodes, nodesById)
+    if (hits.length === 0) {
+      errors.push(`No matches for "${rawToken}"`)
+      continue
+    }
+
+    for (const id of hits) {
+      matched.add(id)
+      if (upstream) {
+        for (const u of getUpstream(id, edges)) matched.add(u)
+      }
+      if (downstream) {
+        for (const d of getDownstream(id, edges)) matched.add(d)
+      }
+    }
+  }
+
+  return { matched, errors }
+}

--- a/frontend/src/utils/graph.ts
+++ b/frontend/src/utils/graph.ts
@@ -64,3 +64,29 @@ export function getSubgraph(
     edges: edges.filter((e) => relevantIds.has(e.source) && relevantIds.has(e.target)),
   }
 }
+
+/** Compute the union of subgraphs for multiple pinned nodes. */
+export function getUnionSubgraph(
+  nodeIds: string[],
+  nodes: LineageNode[],
+  edges: LineageEdge[],
+  depth: number = 2,
+  direction: LineageDirection = 'both',
+): { nodes: LineageNode[]; edges: LineageEdge[] } {
+  if (nodeIds.length === 0) return { nodes: [], edges: [] }
+  if (nodeIds.length === 1) return getSubgraph(nodeIds[0], nodes, edges, depth, direction)
+
+  const relevantIds = new Set<string>()
+  for (const nodeId of nodeIds) {
+    relevantIds.add(nodeId)
+    const upstream = direction !== 'downstream' ? getUpstream(nodeId, edges, depth) : new Set<string>()
+    const downstream = direction !== 'upstream' ? getDownstream(nodeId, edges, depth) : new Set<string>()
+    for (const id of upstream) relevantIds.add(id)
+    for (const id of downstream) relevantIds.add(id)
+  }
+
+  return {
+    nodes: nodes.filter((n) => relevantIds.has(n.id)),
+    edges: edges.filter((e) => relevantIds.has(e.source) && relevantIds.has(e.target)),
+  }
+}

--- a/frontend/src/utils/graphTraversal.ts
+++ b/frontend/src/utils/graphTraversal.ts
@@ -73,6 +73,24 @@ export function getFullChain(nodeId: string, edges: LineageEdge[], maxDepth?: nu
   return new Set([nodeId, ...upstream, ...downstream])
 }
 
+/** Get union of dependency chains for multiple nodes. */
+export function getUnionChain(
+  nodeIds: string[],
+  edges: LineageEdge[],
+  maxDepth?: number,
+): Set<string> {
+  if (nodeIds.length === 0) return new Set()
+  if (nodeIds.length === 1) return getFullChain(nodeIds[0], edges, maxDepth)
+
+  const result = new Set<string>()
+  for (const nodeId of nodeIds) {
+    for (const id of getFullChain(nodeId, edges, maxDepth)) {
+      result.add(id)
+    }
+  }
+  return result
+}
+
 /** Check if an edge connects two nodes in the highlighted set. */
 export function isEdgeHighlighted(
   edge: LineageEdge,

--- a/frontend/src/utils/lineageFilters.ts
+++ b/frontend/src/utils/lineageFilters.ts
@@ -12,6 +12,7 @@ export function applyFilters(
   typeFilter: FilterState,
   tagFilter: FilterState,
   folderFilter: FilterState,
+  layerFilter: FilterState = EMPTY_FILTER,
 ): { nodes: LineageNode[]; edges: LineageEdge[] } {
   let filtered = nodes
 
@@ -36,6 +37,16 @@ export function applyFilters(
       filtered = filtered.filter(n => folderFilter.selected.has(n.folder))
     } else {
       filtered = filtered.filter(n => !folderFilter.selected.has(n.folder))
+    }
+  }
+
+  if (layerFilter.selected.size > 0) {
+    if (layerFilter.mode === 'include') {
+      // Include: only nodes whose layer is in the set. Nodes with no layer are excluded.
+      filtered = filtered.filter(n => n.layer != null && layerFilter.selected.has(String(n.layer)))
+    } else {
+      // Exclude: drop nodes whose layer is in the set. Nodes with no layer survive.
+      filtered = filtered.filter(n => n.layer == null || !layerFilter.selected.has(String(n.layer)))
     }
   }
 
@@ -72,14 +83,17 @@ export function computeSubgraphOptions(nodes: LineageNode[]) {
   const tags = new Set<string>()
   const folders = new Set<string>()
   const types = new Set<string>()
+  const layers = new Set<string>()
   for (const n of nodes) {
     for (const t of n.tags) tags.add(t)
     if (n.folder) folders.add(n.folder)
     types.add(n.resource_type)
+    if (n.layer != null) layers.add(String(n.layer))
   }
   return {
     tags: [...tags].sort(),
     folders: [...folders].sort(),
     types: [...types].sort(),
+    layers: [...layers].sort((a, b) => Number(a) - Number(b)),
   }
 }

--- a/src/docglow/__init__.py
+++ b/src/docglow/__init__.py
@@ -1,3 +1,3 @@
 """docglow: Next-generation dbt documentation site generator."""
 
-__version__ = "0.6.1"
+__version__ = "0.7.0"


### PR DESCRIPTION
## Summary

Closes #72

Replace single-model lineage view with a **pin system** that supports multiple models with combined lineage. Serves both analytics engineers (dbt power users) and business users through a dual-mode input.

## What's New

### Pin Bar
A unified selection bar above the lineage graph:
- **Search input** (business users) — type a model name, autocomplete dropdown, click to pin
- **`⚡ dbt` toggle** (power users) — switches input to dbt selection syntax mode
- **Color-coded chips** — pinned models shown as pills (blue for model, green for source, etc.) with `×` to remove
- **Clear all** button when 2+ pins
- **Backspace on empty input** removes the last pin

### dbt Selection Syntax (Power User Path)
Click `⚡ dbt` toggle, type a selector expression, hit Enter:
- `+fct_orders` — pin model and all upstream
- `dim_customers+` — pin model and all downstream
- `+fct_orders+` — pin model, upstream, and downstream
- `tag:finance` — pin all models with that tag
- `stg_*` — glob pattern matching
- Space-separated expressions are unioned: `+fct_orders +dim_customers tag:finance`

### Multi-Model Graph View
- Union of each pinned model's subgraph (respects current depth + direction controls)
- Union of each pinned model's highlight chain (all in-lineage models shown at full opacity, others dimmed)
- Center button fits **all pinned models** in viewport (adjusts padding for N pins)
- Existing filters (Type, Tag, Folder, column search) still work on the combined subgraph

### Cmd+Click to Pin
Hold Cmd (Mac) or Ctrl (Windows/Linux) and click any node on the graph to toggle its pin state — works on both the pinned node itself and models in the lineage.

### URL Encoding
Selections are now URL-shareable:
```
/#/lineage?pins=model.proj.fct_orders,model.proj.dim_customers&depth=3&dir=both
```
Copy the URL, paste it in Slack/docs, and the recipient sees the same view.

## Personas Served

**Analytics Engineer:**
> \"Show me fct_orders and everything dim_customers depends on\"
1. Click ⚡ dbt, type `+fct_orders +dim_customers`, Enter
2. Both models + all upstream are pinned. Shared ancestor `stg_orders` visible.
3. Copy URL, share in Slack

**Business User (PM/analyst):**
> \"How do the orders report and customer report relate?\"
1. Type \"orders\" in search, click `fct_orders`
2. Type \"customers\", click `dim_customers`
3. Sees both lineage trees merged — notices `stg_orders` connecting both
4. Never saw any dbt syntax

## Implementation

**New files:**
- `frontend/src/components/lineage/PinBar.tsx` — search + chips + ⚡ dbt toggle
- `frontend/src/utils/dbtSelect.ts` — dbt selection syntax parser

**Modified:**
- `frontend/src/pages/LineagePage.tsx` — `pinnedIds` set replaces `selectedNodeId`, URL encoding
- `frontend/src/components/lineage/LineageFlow.tsx` — `pinnedIds` prop, union highlight chain, multi-pin center, Cmd+Click handler
- `frontend/src/utils/graph.ts` — `getUnionSubgraph()` for combined subgraphs
- `frontend/src/utils/graphTraversal.ts` — `getUnionChain()` for combined highlight chains
- `frontend/src/pages/ModelPage.tsx` — backwards-compatible single-element pinnedIds

## Not In This PR (Phase 3)
- Shared-lineage visual polish (thicker edges at convergence points where 2+ pinned models overlap)
- Visual pin badge icon on nodes (currently uses the existing amber active-state border)

## Test plan
- [x] TypeScript compiles clean (frontend build)
- [x] 524 Python tests passing
- [ ] Verify CI passes
- [ ] Manual: pin 2+ models via search, see combined lineage
- [ ] Manual: toggle ⚡ dbt mode, enter `+fct_orders`, verify it pins model + upstream
- [ ] Manual: Cmd+Click a node to toggle its pin
- [ ] Manual: copy URL with pins, paste in new tab, verify same view loads
- [ ] Manual: ModelPage lineage still works (single-pin backward compat)