### PR TITLE
fix(docs): enable pymdownx.emoji so material icons render

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,9 @@ markdown_extensions:
   - pymdownx.inlinehilite
   - pymdownx.tabbed:
       alternate_style: true
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - tables
   - toc:
       permalink: true


### PR DESCRIPTION
## Summary

The Cloud page pricing table on docs.docglow.com was showing literal \`:material-check:\` text instead of rendering the checkmark icons.

This is Material for MkDocs' icon syntax, which requires the \`pymdownx.emoji\` extension configured with the Material emoji index and SVG generator. Adding that three-line config fixes it.

## Test plan
- [x] \`mkdocs build --strict\` succeeds
- [x] Verified: 20 \`<svg>\` tags rendered in \`site/cloud/index.html\`, zero literal \`material-check\` text
- [ ] Verify CI passes
- [ ] Verify docs.docglow.com renders checkmarks after deploy