### PR TITLE
fix(server): use no-store for index.html to prevent stale cached sites

### DIFF
--- a/src/docglow/server/dev.py
+++ b/src/docglow/server/dev.py
@@ -20,9 +20,23 @@ class _DocglowHandler(SimpleHTTPRequestHandler):
         logger.info(format, *args)
 
     def end_headers(self) -> None:
-        """Add CORS and cache headers for local dev."""
+        """Add CORS and cache headers for local dev.
+
+        index.html and docglow-data.json get ``no-store`` so the browser
+        always fetches the latest version after a regenerate.  Hashed
+        assets (JS/CSS with content hashes in the filename) are immutable
+        and can be cached indefinitely.
+        """
         self.send_header("Access-Control-Allow-Origin", "*")
-        self.send_header("Cache-Control", "no-cache")
+
+        path = self.path.split("?")[0].split("#")[0]
+        if path in ("/", "/index.html", "/docglow-data.json"):
+            self.send_header("Cache-Control", "no-store")
+        elif "/assets/" in path:
+            self.send_header("Cache-Control", "public, max-age=31536000, immutable")
+        else:
+            self.send_header("Cache-Control", "no-cache")
+
         super().end_headers()
 
 


### PR DESCRIPTION
## Summary

- Changes `Cache-Control` header strategy on the dev server to prevent browsers from serving stale `index.html` after regenerating a site
- `index.html` and `docglow-data.json` → `no-store` (always fetch fresh)
- Hashed assets (`/assets/*`) → `immutable, max-age=1yr` (content-hashed, safe to cache forever)
- All other files → `no-cache` (unchanged)

Related to #72

## Test plan

- [ ] Run `docglow serve`, inspect response headers for `/` — should be `Cache-Control: no-store`
- [ ] Inspect headers for `/assets/index-*.js` — should be `Cache-Control: public, max-age=31536000, immutable`
- [ ] Inspect headers for `/favicon.svg` — should be `Cache-Control: no-cache`
- [ ] Regenerate site while server is running, hard-refresh browser — should show new content immediately
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)