### PR TITLE
fix(transforms): normalize Windows backslash paths from dbt manifests

### DIFF
--- a/src/docglow/generator/transforms/models.py
+++ b/src/docglow/generator/transforms/models.py
@@ -79,7 +79,7 @@ def transform_model(
         "materialization": (node.config.materialized or ""),
         "tags": list(node.tags),
         "meta": dict(node.meta),
-        "path": node.original_file_path,
+        "path": node.original_file_path.replace("\\", "/"),
         "folder": _get_folder(node.original_file_path),
         "raw_sql": node.raw_code,
         "compiled_sql": node.compiled_code or "",
@@ -94,8 +94,13 @@ def transform_model(
 
 
 def _get_folder(path: str) -> str:
-    """Extract the folder from a model path."""
-    parts = path.rsplit("/", 1)
+    """Extract the folder from a model path.
+
+    Normalizes backslashes to forward slashes first, since dbt on Windows
+    writes paths with backslashes in the manifest (e.g. ``models\\billing\\base\\model.sql``).
+    """
+    normalized = path.replace("\\", "/")
+    parts = normalized.rsplit("/", 1)
     return parts[0] if len(parts) > 1 else ""
 
 

--- a/tests/test_data_transformer.py
+++ b/tests/test_data_transformer.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from docglow import __version__
 from docglow.artifacts.loader import load_artifacts
 from docglow.generator.data import build_docglow_data
+from docglow.generator.transforms.models import _get_folder
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
@@ -236,6 +237,16 @@ class TestBuildDocglowData:
 
         assert orders["path"] != ""
         assert orders["folder"] != ""
+
+    def test_get_folder_forward_slashes(self) -> None:
+        assert _get_folder("models/staging/stg_orders.sql") == "models/staging"
+
+    def test_get_folder_backslashes(self) -> None:
+        """Windows dbt manifests use backslashes in paths."""
+        assert _get_folder("models\\billing\\base\\base_invoice.sql") == "models/billing/base"
+
+    def test_get_folder_no_directory(self) -> None:
+        assert _get_folder("model.sql") == ""
 
     def test_sources_populated(self, tmp_path: Path) -> None:
         data = _load_fixtures(tmp_path)

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -247,6 +247,25 @@ class TestNaming:
         result = check_naming(models, rules)
         assert result.total_checked == 0
 
+    def test_windows_backslash_paths(self) -> None:
+        """Paths normalized from Windows manifests should still detect layers."""
+        rules = NamingRules(
+            rules=(
+                ("base", (r"^base_",)),
+                ("staging", (r"^stg_",)),
+            )
+        )
+        # After _get_folder normalizes backslashes, folder will be "models/billing/base"
+        models = {
+            "m1": _make_model(
+                name="base_invoice",
+                folder="models/billing/base",
+                path="models/billing/base/base_invoice.sql",
+            )
+        }
+        result = check_naming(models, rules)
+        assert result.compliance_rate == 1.0
+
 
 class TestHealthScore:
     def test_perfect_health(self) -> None:


### PR DESCRIPTION
## Summary

- Normalizes `\` → `/` in `_get_folder()` and the stored `path` field when reading `original_file_path` from dbt manifests
- dbt on Windows writes backslash paths (e.g. `models\billing\base\model.sql`), which caused `_get_folder()` to return an empty string — breaking layer detection for all folder-based rules

This is the actual root cause of #80. The dynamic naming rules fix (PR #81) was correct but insufficient — on Windows, the folder was always empty so no layer could ever match by folder.

## What changed

| File | Change |
|---|---|
| `src/docglow/generator/transforms/models.py` | `_get_folder()` normalizes `\` → `/` before splitting; `path` field also normalized |
| `tests/test_data_transformer.py` | 3 new unit tests for `_get_folder` (forward slashes, backslashes, no directory) |
| `tests/test_health.py` | 1 new test for Windows-normalized paths in naming compliance |

## Test plan

- [x] 534 tests pass
- [x] `_get_folder("models\\billing\\base\\base_invoice.sql")` returns `"models/billing/base"`
- [x] Naming compliance detects `base` layer from normalized folder path
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)