### PR TITLE
chore: release v0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.7.2] - 2026-04-19
+
+### Fixed
+- **Windows path normalization** — dbt on Windows writes backslash paths in the manifest (e.g. `models\billing\base\model.sql`). The folder extraction only split on forward slashes, so the folder was always empty and layer detection could never match by folder. Now normalizes `\` → `/` before parsing. (#80)
+
 ## [0.7.1] - 2026-04-19
 
 ### Fixed

--- a/src/docglow/__init__.py
+++ b/src/docglow/__init__.py
@@ -1,3 +1,3 @@
 """docglow: Next-generation dbt documentation site generator."""
 
-__version__ = "0.7.1"
+__version__ = "0.7.2"


### PR DESCRIPTION
## Summary

- Bump version to 0.7.2
- Update CHANGELOG.md

### Fix in this release
- **Windows path normalization** — backslash paths from Windows dbt manifests caused empty folder extraction, breaking all folder-based layer detection (#80)

## Test plan

- [x] 534 tests pass
- [ ] CI passes
- [ ] After merge: tag `v0.7.2`, create GitHub release, publish to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)