### PR TITLE
fix: handle missing database field in dbt manifests (#87)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- **Missing database field in manifest** — dbt adapters that don't populate `database` (e.g. `dbt-glue`, `dbt-spark`, `dbt-athena`) caused the model and source headers to render with a leading period (`.my_schema`). Added a `formatFqn` helper that skips empty segments so the header now renders `my_schema` alone, or `database.schema` when both are present. (#87)
+
 ## [0.7.2] - 2026-04-19
 
 ### Fixed

--- a/frontend/src/__tests__/formatting.test.ts
+++ b/frontend/src/__tests__/formatting.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { formatFqn } from '../utils/formatting'
+
+describe('formatFqn', () => {
+  it('joins database, schema, and name with dots', () => {
+    expect(formatFqn({ database: 'analytics', schema: 'public', name: 'orders' })).toBe(
+      'analytics.public.orders'
+    )
+  })
+
+  it('joins database and schema when name is omitted', () => {
+    expect(formatFqn({ database: 'analytics', schema: 'public' })).toBe('analytics.public')
+  })
+
+  it('drops empty database (dbt-glue / dbt-spark case)', () => {
+    expect(formatFqn({ database: '', schema: 'my_schema', name: 'orders' })).toBe(
+      'my_schema.orders'
+    )
+  })
+
+  it('drops empty database with no name', () => {
+    expect(formatFqn({ database: '', schema: 'my_schema' })).toBe('my_schema')
+  })
+
+  it('drops empty schema', () => {
+    expect(formatFqn({ database: 'db', schema: '', name: 'orders' })).toBe('db.orders')
+  })
+
+  it('returns empty string when all segments are empty', () => {
+    expect(formatFqn({ database: '', schema: '' })).toBe('')
+  })
+
+  it('treats null and undefined as empty', () => {
+    expect(formatFqn({ database: null, schema: 'public', name: 'orders' })).toBe(
+      'public.orders'
+    )
+    expect(formatFqn({ database: undefined, schema: 'public' })).toBe('public')
+  })
+})

--- a/frontend/src/pages/ModelPage.tsx
+++ b/frontend/src/pages/ModelPage.tsx
@@ -10,6 +10,7 @@ import { FilterDropdown } from '../components/ui/FilterDropdown'
 import type { FilterState } from '../components/ui/FilterDropdown'
 import { Markdown } from '../components/Markdown'
 import { materializationLabel } from '../utils/colors'
+import { formatFqn } from '../utils/formatting'
 import { getSubgraph, type LineageDirection } from '../utils/graph'
 import { applyFilters, useFilterState, computeSubgraphOptions } from '../utils/lineageFilters'
 import { buildModelColumnsMap } from '../utils/modelColumns'
@@ -212,7 +213,7 @@ export function ModelPage() {
           <TestBadge status={overallTestStatus} />
         </div>
         <div className="text-sm text-[var(--text-muted)] flex gap-4">
-          <span>{model.database}.{model.schema}</span>
+          <span>{formatFqn({ database: model.database, schema: model.schema })}</span>
           <span>{model.path}</span>
         </div>
         {model.description && (

--- a/frontend/src/pages/SourcePage.tsx
+++ b/frontend/src/pages/SourcePage.tsx
@@ -2,6 +2,7 @@ import { useParams } from 'react-router-dom'
 import { useProjectStore } from '../stores/projectStore'
 import { ColumnTable } from '../components/models/ColumnTable'
 import { Markdown } from '../components/Markdown'
+import { formatFqn } from '../utils/formatting'
 
 export function SourcePage() {
   const { id } = useParams<{ id: string }>()
@@ -27,7 +28,7 @@ export function SourcePage() {
           </span>
         </div>
         <div className="text-sm text-[var(--text-muted)] flex gap-4">
-          <span>{source.database}.{source.schema}</span>
+          <span>{formatFqn({ database: source.database, schema: source.schema })}</span>
           {source.loader && <span>Loader: {source.loader}</span>}
         </div>
         {source.description && (

--- a/frontend/src/utils/formatting.ts
+++ b/frontend/src/utils/formatting.ts
@@ -25,6 +25,14 @@ export function formatDuration(seconds: number | null | undefined): string {
   return `${Math.floor(seconds / 60)}m ${Math.round(seconds % 60)}s`
 }
 
+export function formatFqn(parts: {
+  database?: string | null
+  schema?: string | null
+  name?: string | null
+}): string {
+  return [parts.database, parts.schema, parts.name].filter(Boolean).join('.')
+}
+
 export function timeAgo(isoString: string | null | undefined): string {
   if (!isoString) return '—'
   const date = new Date(isoString)

--- a/packages/shared-types/src/models.ts
+++ b/packages/shared-types/src/models.ts
@@ -93,6 +93,12 @@ export interface DocglowModel {
   readonly name: string;
   readonly description: string;
   readonly schema: string;
+  /**
+   * Database/catalog name. Empty string (`''`) when the dbt adapter does not
+   * populate it (e.g. dbt-glue, dbt-spark, dbt-athena). Consumers must handle
+   * the empty case — do not concatenate `database.schema` unconditionally.
+   * Use `formatFqn` from `frontend/src/utils/formatting.ts` for display.
+   */
   readonly database: string;
   readonly materialization: string;
   readonly tags: string[];
@@ -118,6 +124,12 @@ export interface DocglowSource {
   readonly source_name: string;
   readonly description: string;
   readonly schema: string;
+  /**
+   * Database/catalog name. Empty string (`''`) when the dbt adapter does not
+   * populate it (e.g. dbt-glue, dbt-spark, dbt-athena). Consumers must handle
+   * the empty case — do not concatenate `database.schema` unconditionally.
+   * Use `formatFqn` from `frontend/src/utils/formatting.ts` for display.
+   */
   readonly database: string;
   readonly columns: DocglowColumn[];
   readonly tags: string[];

--- a/tests/test_data_transformer.py
+++ b/tests/test_data_transformer.py
@@ -4,9 +4,12 @@ import json
 from pathlib import Path
 
 from docglow import __version__
+from docglow.artifacts.catalog import Catalog
 from docglow.artifacts.loader import load_artifacts
+from docglow.artifacts.manifest import ManifestNode, ManifestSource
 from docglow.generator.data import build_docglow_data
-from docglow.generator.transforms.models import _get_folder
+from docglow.generator.transforms.models import _get_folder, transform_model
+from docglow.generator.transforms.sources import transform_source
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
@@ -438,3 +441,31 @@ class TestPackageFiltering:
 
         source_ids = {n["id"] for n in lineage["nodes"] if n["resource_type"] == "source"}
         assert len(source_ids) > 0
+
+
+class TestMissingDatabase:
+    """Regression tests for dbt adapters that omit the database field (dbt-glue, dbt-spark)."""
+
+    def test_model_transform_coerces_null_database_to_empty_string(self) -> None:
+        node = ManifestNode(
+            unique_id="model.project.orders",
+            name="orders",
+            resource_type="model",
+            database=None,
+            schema="my_schema",
+        )
+        result = transform_model(node, Catalog(), {}, {}, {})
+        assert result["database"] == ""
+        assert result["schema"] == "my_schema"
+
+    def test_source_transform_coerces_null_database_to_empty_string(self) -> None:
+        source = ManifestSource(
+            unique_id="source.project.raw.events",
+            name="events",
+            source_name="raw",
+            database=None,
+            schema="my_schema",
+        )
+        result = transform_source(source, Catalog(), None)
+        assert result["database"] == ""
+        assert result["schema"] == "my_schema"


### PR DESCRIPTION
## Summary
- Fixes #87 — some dbt adapters (`dbt-glue`, `dbt-spark`, `dbt-athena`) don't populate `database` in the manifest, causing the model and source page headers to render with a leading period (`.my_schema`).
- Adds a tiny `formatFqn()` helper in `frontend/src/utils/formatting.ts` that joins truthy segments with `.`, and swaps the two render sites (`ModelPage.tsx`, `SourcePage.tsx`) to use it.
- Adds Python regression tests locking the `null → ""` coercion at the `transform_model` / `transform_source` boundary, and JSDoc on `DocglowModel.database` / `DocglowSource.database` documenting the empty-string sentinel.

No breaking change — the generated JSON still uses `""` for absent database, so existing consumers keep working.

## Files touched
- `frontend/src/utils/formatting.ts` — new `formatFqn()` export
- `frontend/src/__tests__/formatting.test.ts` — 7 unit tests (all edge cases)
- `frontend/src/pages/ModelPage.tsx`, `SourcePage.tsx` — swap render sites
- `packages/shared-types/src/models.ts` — JSDoc documenting convention
- `tests/test_data_transformer.py` — 2 pytest regressions
- `CHANGELOG.md` — entry under `[Unreleased] > Fixed`

## Test plan
- [x] `pytest` — 536 passed (incl. 2 new regression tests)
- [x] `vitest` — 79 passed (incl. 7 new `formatFqn` tests)
- [x] `ruff check`, `ruff format --check`, `mypy`, `tsc --noEmit` — all clean
- [ ] Manual: regenerate `examples/jaffle-shop` and confirm no regression on adapters that DO populate `database` (still renders `analytics.public`)
- [ ] Manual (reviewer): verify any other FQN composition sites exist via `rg '\{.*database.*\}\.\{.*schema' frontend/src` and `rg 'model\.database|source\.database' frontend/src` — only the two swapped sites matched at time of writing

## How to reproduce the fix locally (dbt-glue simulation)

Since jaffle-shop populates `database`, I verified the fix end-to-end by forging a manifest with every `database` nulled (mimicking what `dbt-glue` / `dbt-spark` emit):

```bash
# 1. Craft a dbt-glue-style manifest (null all databases)
mkdir -p /tmp/docglow-glue-test/target
jq '
  .nodes |= with_entries(.value.database = null) |
  .sources |= with_entries(.value.database = null) |
  .exposures |= with_entries(.value.database = null)
' examples/jaffle-shop/target/manifest.json > /tmp/docglow-glue-test/target/manifest.json
cp examples/jaffle-shop/target/{catalog,run_results}.json /tmp/docglow-glue-test/target/

# 2. Build frontend + install docglow editable
(cd frontend && npm run build:sync) && pip install -e .

# 3. Generate + serve
docglow generate --project-dir /tmp/docglow-glue-test --output-dir /tmp/docglow-glue-test/site --static
(cd /tmp/docglow-glue-test/site && python3 -m http.server 8766)
```

### Results I observed

| Page | Before | After |
|------|--------|-------|
| ModelPage `customers` (null db) | `.main` | `main` ✅ |
| SourcePage `raw_customers` (null db) | `.raw` | `raw` ✅ |
| ModelPage `customers` (db populated — happy path) | `jaffle_shop.main` | `jaffle_shop.main` ✅ no regression |
