### PR TITLE
feat(cli): add post-generate Docglow Cloud hint with user-dismiss controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **Docglow Cloud hint after `docglow generate`** — prints a single non-intrusive line pointing to docglow.com/cloud after a successful generate. Suppress with `DOCGLOW_NO_CLOUD_HINT=1`; auto-suppressed when `CI=true`; rate-limited to once per 24h per machine. Permanently dismiss on this machine with `docglow cloud hide-hint` (and re-enable with `docglow cloud show-hint`).
+
 ## [0.7.3] - 2026-04-22
 
 ### Fixed

--- a/src/docglow/cli.py
+++ b/src/docglow/cli.py
@@ -7,7 +7,7 @@ from rich.console import Console
 from rich.logging import RichHandler
 
 from docglow import __version__
-from docglow.commands.cloud import login, logout, setup, status
+from docglow.commands.cloud import cloud_group, login, logout, setup, status
 from docglow.commands.generate import generate
 from docglow.commands.health import health
 from docglow.commands.init import init
@@ -54,5 +54,6 @@ cli.add_command(login)
 cli.add_command(logout)
 cli.add_command(status)
 cli.add_command(setup)
+cli.add_command(cloud_group)
 cli.add_command(mcp_server)
 cli.add_command(init)

--- a/src/docglow/cloud_hint.py
+++ b/src/docglow/cloud_hint.py
@@ -1,0 +1,177 @@
+"""Non-intrusive Docglow Cloud hint shown after `docglow generate`.
+
+Suppression precedence (highest wins):
+    1. DOCGLOW_NO_CLOUD_HINT=1 env var
+    2. CI=true env var
+    3. dismissed_at set in state file (via `docglow cloud hide-hint`)
+    4. Shown within FREQUENCY_WINDOW (24h) per machine
+    5. Default: show and record timestamp
+
+State is persisted in a small JSON file under `click.get_app_dir("docglow")`.
+All I/O failures are swallowed — this feature must never break `generate`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Mapping
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import click
+
+CLOUD_URL = "https://docglow.com/cloud"
+SUPPRESS_ENV = "DOCGLOW_NO_CLOUD_HINT"
+CI_ENV = "CI"
+FREQUENCY_WINDOW = timedelta(hours=24)
+STATE_FILENAME = "cloud_hint.json"
+STATE_VERSION = 1
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def _state_path() -> Path:
+    """Return the path to the hint state file. Factored out for test monkeypatching."""
+    return Path(click.get_app_dir("docglow")) / STATE_FILENAME
+
+
+def _is_truthy(value: str | None) -> bool:
+    if value is None:
+        return False
+    return value.strip().lower() in _TRUTHY
+
+
+def _read_payload(path: Path) -> dict[str, object]:
+    """Return the validated state payload, or an empty dict on missing/corrupt input."""
+    try:
+        raw = path.read_text(encoding="utf-8")
+        payload = json.loads(raw)
+        if not isinstance(payload, dict):
+            return {}
+        if payload.get("version") != STATE_VERSION:
+            return {}
+        return payload
+    except Exception:
+        return {}
+
+
+def _parse_iso8601(value: object) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _read_state(path: Path) -> datetime | None:
+    """Return the last-shown timestamp, or None if missing/invalid."""
+    return _parse_iso8601(_read_payload(path).get("last_shown_at"))
+
+
+def _read_dismissed_at(path: Path) -> datetime | None:
+    """Return the dismissed-at timestamp, or None if not dismissed."""
+    return _parse_iso8601(_read_payload(path).get("dismissed_at"))
+
+
+def _write_payload(path: Path, payload: dict[str, object]) -> None:
+    """Atomically persist a state payload. Swallows all exceptions."""
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_text(json.dumps(payload), encoding="utf-8")
+        os.replace(tmp, path)
+    except Exception:
+        # Best-effort: a failed write just means the hint may show again sooner.
+        pass
+
+
+def _write_state(path: Path, now: datetime) -> None:
+    """Persist the last-shown timestamp while preserving any dismissed_at field."""
+    existing = _read_payload(path)
+    payload: dict[str, object] = {
+        "version": STATE_VERSION,
+        "last_shown_at": now.astimezone(timezone.utc).isoformat(),
+    }
+    dismissed_at = existing.get("dismissed_at")
+    if isinstance(dismissed_at, str):
+        payload["dismissed_at"] = dismissed_at
+    _write_payload(path, payload)
+
+
+def _write_dismissed_at(path: Path, when: datetime | None) -> None:
+    """Set or clear the dismissed_at field while preserving any last_shown_at field.
+
+    Passing `None` removes the dismissed_at field.
+    """
+    existing = _read_payload(path)
+    payload: dict[str, object] = {"version": STATE_VERSION}
+    last_shown_at = existing.get("last_shown_at")
+    if isinstance(last_shown_at, str):
+        payload["last_shown_at"] = last_shown_at
+    if when is not None:
+        payload["dismissed_at"] = when.astimezone(timezone.utc).isoformat()
+    _write_payload(path, payload)
+
+
+def set_dismissed(now: datetime | None = None) -> None:
+    """Mark the Cloud hint as dismissed. Used by `docglow cloud hide-hint`."""
+    _write_dismissed_at(_state_path(), now or datetime.now(timezone.utc))
+
+
+def clear_dismissed() -> None:
+    """Re-enable the Cloud hint. Used by `docglow cloud show-hint`."""
+    _write_dismissed_at(_state_path(), None)
+
+
+def should_show_hint(
+    now: datetime,
+    env: Mapping[str, str],
+    state_path: Path,
+) -> bool:
+    """Apply the suppression precedence rules."""
+    if _is_truthy(env.get(SUPPRESS_ENV)):
+        return False
+    if _is_truthy(env.get(CI_ENV)):
+        return False
+    if _read_dismissed_at(state_path) is not None:
+        return False
+    last_shown = _read_state(state_path)
+    if last_shown is not None and (now - last_shown) < FREQUENCY_WINDOW:
+        return False
+    return True
+
+
+def render_hint(version: str) -> str:
+    """Return the Rich-markup hint string with UTM attribution and dismiss tip.
+
+    UTM params are used (instead of custom keys) so PostHog and other
+    analytics tools auto-capture them without extra configuration.
+    """
+    url = f"{CLOUD_URL}?utm_source=cli&utm_medium=cli&utm_campaign=generate&utm_content=v{version}"
+    return (
+        f"\n[dim]:bulb: Docglow Cloud: hosted docs + AI Q&A + Slack bot → {url}[/dim]"
+        f"\n[dim]   (run `docglow cloud hide-hint` to dismiss)[/dim]"
+    )
+
+
+def maybe_show_hint(console: object, version: str) -> None:
+    """Print the hint if suppression rules allow, then record state.
+
+    Never raises. `console` is a rich.console.Console but typed as object to
+    keep this module free of rich-typing coupling.
+    """
+    try:
+        now = datetime.now(timezone.utc)
+        path = _state_path()
+        if not should_show_hint(now, os.environ, path):
+            return
+        console.print(render_hint(version))  # type: ignore[attr-defined]
+        _write_state(path, now)
+    except Exception:
+        # Never let the hint break the generate command.
+        pass

--- a/src/docglow/commands/cloud.py
+++ b/src/docglow/commands/cloud.py
@@ -111,3 +111,31 @@ def setup() -> None:
     save_cloud_config(workspace_slug=workspace, project_slug=project)
     console.print("\n[bold green]Setup complete![/bold green]")
     console.print("  Config saved to ~/.docglow/config.json")
+
+
+@click.group(name="cloud")
+def cloud_group() -> None:
+    """Manage Docglow Cloud preferences."""
+
+
+@cloud_group.command(name="hide-hint")
+def hide_hint() -> None:
+    """Permanently dismiss the post-generate Docglow Cloud hint on this machine."""
+    from docglow.cli import console
+    from docglow.cloud_hint import set_dismissed
+
+    set_dismissed()
+    console.print(
+        "[bold green]✓[/bold green] Cloud hint dismissed. "
+        "Run [bold]docglow cloud show-hint[/bold] to re-enable."
+    )
+
+
+@cloud_group.command(name="show-hint")
+def show_hint() -> None:
+    """Re-enable the post-generate Docglow Cloud hint on this machine."""
+    from docglow.cli import console
+    from docglow.cloud_hint import clear_dismissed
+
+    clear_dismissed()
+    console.print("[bold green]✓[/bold green] Cloud hint re-enabled.")

--- a/src/docglow/commands/generate.py
+++ b/src/docglow/commands/generate.py
@@ -4,6 +4,9 @@ from pathlib import Path
 
 import click
 
+from docglow import __version__
+from docglow.cloud_hint import maybe_show_hint
+
 
 @click.command()
 @click.option("--project-dir", type=click.Path(exists=True, path_type=Path), default=".")
@@ -200,6 +203,8 @@ def generate(
                     f"\n[bold green]Health score: {health_score:.0f} "
                     f"(threshold: {fail_under:.0f})[/bold green]"
                 )
+
+        maybe_show_hint(console, __version__)
     except ArtifactLoadError as e:
         console.print(f"[bold red]Error:[/bold red] {e}")
         raise SystemExit(1) from e

--- a/tests/test_cli_cloud_hint.py
+++ b/tests/test_cli_cloud_hint.py
@@ -1,0 +1,165 @@
+"""Integration tests for the Docglow Cloud hint in `docglow generate`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from docglow import cloud_hint
+from docglow.cli import cli
+
+
+def _mock_config() -> MagicMock:
+    config = MagicMock()
+    config.ai.enabled = False
+    config.title = "docglow"
+    config.slim = False
+    config.column_lineage = True
+    return config
+
+
+@pytest.fixture(autouse=True)
+def isolated_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect the hint state file to tmp so tests don't pollute ~/.config/docglow."""
+    state = tmp_path / "cloud_hint.json"
+    monkeypatch.setattr(cloud_hint, "_state_path", lambda: state)
+    monkeypatch.delenv("DOCGLOW_NO_CLOUD_HINT", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    return state
+
+
+def _invoke_generate(tmp_path: Path) -> object:
+    runner = CliRunner()
+    with (
+        patch("docglow.config.load_config", return_value=_mock_config()),
+        patch(
+            "docglow.generator.site.generate_site",
+            return_value=(tmp_path / "output", 85.0),
+        ),
+    ):
+        return runner.invoke(cli, ["generate", "--project-dir", str(tmp_path)])
+
+
+def test_generate_prints_cloud_hint_on_success(tmp_path: Path) -> None:
+    result = _invoke_generate(tmp_path)
+    assert result.exit_code == 0
+    assert "Docglow Cloud" in result.output
+    assert "utm_source=cli" in result.output
+
+
+def test_generate_suppresses_hint_with_env_var(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DOCGLOW_NO_CLOUD_HINT", "1")
+    result = _invoke_generate(tmp_path)
+    assert result.exit_code == 0
+    assert "Docglow Cloud" not in result.output
+
+
+def test_generate_suppresses_hint_in_ci(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CI", "true")
+    result = _invoke_generate(tmp_path)
+    assert result.exit_code == 0
+    assert "Docglow Cloud" not in result.output
+
+
+def test_generate_hint_not_shown_when_fail_under_trips(tmp_path: Path) -> None:
+    runner = CliRunner()
+    with (
+        patch("docglow.config.load_config", return_value=_mock_config()),
+        patch(
+            "docglow.generator.site.generate_site",
+            return_value=(tmp_path / "output", 40.0),
+        ),
+    ):
+        result = runner.invoke(
+            cli,
+            ["generate", "--project-dir", str(tmp_path), "--fail-under", "70"],
+        )
+
+    assert result.exit_code == 1
+    assert "Docglow Cloud" not in result.output
+
+
+def test_generate_hint_not_shown_on_artifact_error(
+    tmp_path: Path,
+) -> None:
+    from docglow.artifacts.loader import ArtifactLoadError
+
+    runner = CliRunner()
+    with (
+        patch("docglow.config.load_config", return_value=_mock_config()),
+        patch(
+            "docglow.generator.site.generate_site",
+            side_effect=ArtifactLoadError("missing manifest"),
+        ),
+    ):
+        result = runner.invoke(cli, ["generate", "--project-dir", str(tmp_path)])
+
+    assert result.exit_code == 1
+    assert "Docglow Cloud" not in result.output
+
+
+# --- `docglow cloud hide-hint` / `show-hint` subcommands ---
+
+
+def test_cloud_help_lists_hint_subcommands() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["cloud", "--help"])
+    assert result.exit_code == 0
+    assert "hide-hint" in result.output
+    assert "show-hint" in result.output
+
+
+def test_cloud_hide_hint_writes_dismissed_state(isolated_state: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["cloud", "hide-hint"])
+    assert result.exit_code == 0
+    assert "dismissed" in result.output.lower()
+    assert cloud_hint._read_dismissed_at(isolated_state) is not None
+
+
+def test_cloud_show_hint_clears_dismissed_state(isolated_state: Path) -> None:
+    runner = CliRunner()
+    runner.invoke(cli, ["cloud", "hide-hint"])
+    assert cloud_hint._read_dismissed_at(isolated_state) is not None
+    result = runner.invoke(cli, ["cloud", "show-hint"])
+    assert result.exit_code == 0
+    assert "re-enabled" in result.output.lower()
+    assert cloud_hint._read_dismissed_at(isolated_state) is None
+
+
+def test_cloud_show_hint_idempotent_when_not_dismissed(isolated_state: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["cloud", "show-hint"])
+    assert result.exit_code == 0
+    assert cloud_hint._read_dismissed_at(isolated_state) is None
+
+
+def test_cloud_hide_hint_idempotent_when_called_twice(isolated_state: Path) -> None:
+    runner = CliRunner()
+    result1 = runner.invoke(cli, ["cloud", "hide-hint"])
+    result2 = runner.invoke(cli, ["cloud", "hide-hint"])
+    assert result1.exit_code == 0
+    assert result2.exit_code == 0
+    assert cloud_hint._read_dismissed_at(isolated_state) is not None
+
+
+def test_generate_suppresses_hint_after_hide_hint(tmp_path: Path) -> None:
+    runner = CliRunner()
+    runner.invoke(cli, ["cloud", "hide-hint"])
+    result = _invoke_generate(tmp_path)
+    assert result.exit_code == 0
+    assert "Docglow Cloud" not in result.output
+
+
+def test_generate_resumes_hint_after_show_hint(tmp_path: Path) -> None:
+    runner = CliRunner()
+    runner.invoke(cli, ["cloud", "hide-hint"])
+    runner.invoke(cli, ["cloud", "show-hint"])
+    result = _invoke_generate(tmp_path)
+    assert result.exit_code == 0
+    assert "Docglow Cloud" in result.output

--- a/tests/test_cloud_hint.py
+++ b/tests/test_cloud_hint.py
@@ -1,0 +1,321 @@
+"""Unit tests for docglow.cloud_hint suppression and state handling."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from docglow import cloud_hint
+from docglow.cloud_hint import (
+    FREQUENCY_WINDOW,
+    STATE_VERSION,
+    _read_dismissed_at,
+    _read_state,
+    _write_dismissed_at,
+    _write_state,
+    clear_dismissed,
+    maybe_show_hint,
+    render_hint,
+    set_dismissed,
+    should_show_hint,
+)
+
+
+@pytest.fixture
+def state_path(tmp_path: Path) -> Path:
+    return tmp_path / "docglow" / "cloud_hint.json"
+
+
+@pytest.fixture
+def fixed_now() -> datetime:
+    return datetime(2026, 4, 24, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def test_should_show_hint_first_run(state_path: Path, fixed_now: datetime) -> None:
+    assert should_show_hint(fixed_now, {}, state_path) is True
+
+
+def test_should_show_hint_suppressed_by_env_var(state_path: Path, fixed_now: datetime) -> None:
+    assert should_show_hint(fixed_now, {"DOCGLOW_NO_CLOUD_HINT": "1"}, state_path) is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "On"])
+def test_should_show_hint_env_var_truthy_variants(
+    state_path: Path, fixed_now: datetime, value: str
+) -> None:
+    assert should_show_hint(fixed_now, {"DOCGLOW_NO_CLOUD_HINT": value}, state_path) is False
+
+
+@pytest.mark.parametrize("value", ["0", "", "false", "no"])
+def test_should_show_hint_env_var_falsy_variants(
+    state_path: Path, fixed_now: datetime, value: str
+) -> None:
+    assert should_show_hint(fixed_now, {"DOCGLOW_NO_CLOUD_HINT": value}, state_path) is True
+
+
+def test_should_show_hint_suppressed_in_ci(state_path: Path, fixed_now: datetime) -> None:
+    assert should_show_hint(fixed_now, {"CI": "true"}, state_path) is False
+
+
+def test_should_show_hint_within_window(state_path: Path, fixed_now: datetime) -> None:
+    recent = fixed_now - timedelta(hours=1)
+    _write_state(state_path, recent)
+    assert should_show_hint(fixed_now, {}, state_path) is False
+
+
+def test_should_show_hint_outside_window(state_path: Path, fixed_now: datetime) -> None:
+    stale = fixed_now - timedelta(hours=25)
+    _write_state(state_path, stale)
+    assert should_show_hint(fixed_now, {}, state_path) is True
+
+
+def test_should_show_hint_corrupt_state_file(state_path: Path, fixed_now: datetime) -> None:
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text("not json", encoding="utf-8")
+    assert should_show_hint(fixed_now, {}, state_path) is True
+
+
+def test_should_show_hint_missing_timestamp_field(state_path: Path, fixed_now: datetime) -> None:
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(json.dumps({"version": STATE_VERSION}), encoding="utf-8")
+    assert should_show_hint(fixed_now, {}, state_path) is True
+
+
+def test_should_show_hint_unknown_state_version(state_path: Path, fixed_now: datetime) -> None:
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        json.dumps({"version": 99, "last_shown_at": fixed_now.isoformat()}),
+        encoding="utf-8",
+    )
+    assert should_show_hint(fixed_now, {}, state_path) is True
+
+
+def test_read_state_missing_file(state_path: Path) -> None:
+    assert _read_state(state_path) is None
+
+
+def test_write_state_creates_parent_dir(state_path: Path, fixed_now: datetime) -> None:
+    assert not state_path.parent.exists()
+    _write_state(state_path, fixed_now)
+    assert state_path.exists()
+    loaded = _read_state(state_path)
+    assert loaded is not None
+    assert loaded == fixed_now
+
+
+def test_write_state_atomic_overwrite(state_path: Path, fixed_now: datetime) -> None:
+    _write_state(state_path, fixed_now)
+    later = fixed_now + timedelta(hours=5)
+    _write_state(state_path, later)
+    loaded = _read_state(state_path)
+    assert loaded == later
+
+
+def test_write_state_swallows_errors(
+    state_path: Path, fixed_now: datetime, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def boom(*args: object, **kwargs: object) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(os, "replace", boom)
+    # Must not raise.
+    _write_state(state_path, fixed_now)
+
+
+def test_render_hint_contains_utm_attribution() -> None:
+    output = render_hint("0.7.3")
+    assert "docglow.com/cloud?" in output
+    assert "utm_source=cli" in output
+    assert "utm_medium=cli" in output
+    assert "utm_campaign=generate" in output
+    assert "utm_content=v0.7.3" in output
+    assert ":bulb:" in output
+
+
+def test_render_hint_contains_dismiss_tip() -> None:
+    output = render_hint("0.7.3")
+    assert "hide-hint" in output
+    assert "dismiss" in output
+
+
+def test_maybe_show_hint_env_var_wins_over_everything(
+    state_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(cloud_hint, "_state_path", lambda: state_path)
+    monkeypatch.setenv("DOCGLOW_NO_CLOUD_HINT", "1")
+    monkeypatch.delenv("CI", raising=False)
+    console = MagicMock()
+    maybe_show_hint(console, "0.7.3")
+    console.print.assert_not_called()
+    assert not state_path.exists()
+
+
+def test_maybe_show_hint_ci_suppression(state_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cloud_hint, "_state_path", lambda: state_path)
+    monkeypatch.delenv("DOCGLOW_NO_CLOUD_HINT", raising=False)
+    monkeypatch.setenv("CI", "true")
+    console = MagicMock()
+    maybe_show_hint(console, "0.7.3")
+    console.print.assert_not_called()
+    assert not state_path.exists()
+
+
+def test_maybe_show_hint_writes_state_on_show(
+    state_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(cloud_hint, "_state_path", lambda: state_path)
+    monkeypatch.delenv("DOCGLOW_NO_CLOUD_HINT", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    console = MagicMock()
+    maybe_show_hint(console, "0.7.3")
+    console.print.assert_called_once()
+    assert state_path.exists()
+
+
+def test_maybe_show_hint_never_raises(state_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def boom() -> Path:
+        raise RuntimeError("config dir unreadable")
+
+    monkeypatch.setattr(cloud_hint, "_state_path", boom)
+    console = MagicMock()
+    # Must not raise even though _state_path blows up.
+    maybe_show_hint(console, "0.7.3")
+
+
+def test_maybe_show_hint_respects_frequency_cap(
+    state_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(cloud_hint, "_state_path", lambda: state_path)
+    monkeypatch.delenv("DOCGLOW_NO_CLOUD_HINT", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    _write_state(state_path, datetime.now(timezone.utc) - timedelta(hours=1))
+    console = MagicMock()
+    maybe_show_hint(console, "0.7.3")
+    console.print.assert_not_called()
+
+
+def test_frequency_window_is_24h() -> None:
+    assert FREQUENCY_WINDOW == timedelta(hours=24)
+
+
+# --- dismiss-flag tests ---
+
+
+def test_read_dismissed_at_missing_file(state_path: Path) -> None:
+    assert _read_dismissed_at(state_path) is None
+
+
+def test_read_dismissed_at_when_field_present(state_path: Path, fixed_now: datetime) -> None:
+    _write_dismissed_at(state_path, fixed_now)
+    loaded = _read_dismissed_at(state_path)
+    assert loaded is not None
+    assert loaded == fixed_now
+
+
+def test_read_dismissed_at_returns_none_for_corrupt_payload(state_path: Path) -> None:
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text("not json", encoding="utf-8")
+    assert _read_dismissed_at(state_path) is None
+
+
+def test_read_dismissed_at_returns_none_for_unknown_version(
+    state_path: Path, fixed_now: datetime
+) -> None:
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        json.dumps({"version": 99, "dismissed_at": fixed_now.isoformat()}),
+        encoding="utf-8",
+    )
+    assert _read_dismissed_at(state_path) is None
+
+
+def test_write_dismissed_at_preserves_last_shown_at(state_path: Path, fixed_now: datetime) -> None:
+    _write_state(state_path, fixed_now)
+    later = fixed_now + timedelta(hours=2)
+    _write_dismissed_at(state_path, later)
+    assert _read_state(state_path) == fixed_now
+    assert _read_dismissed_at(state_path) == later
+
+
+def test_write_dismissed_at_none_clears_field(state_path: Path, fixed_now: datetime) -> None:
+    _write_state(state_path, fixed_now)
+    _write_dismissed_at(state_path, fixed_now + timedelta(hours=1))
+    assert _read_dismissed_at(state_path) is not None
+    _write_dismissed_at(state_path, None)
+    assert _read_dismissed_at(state_path) is None
+    assert _read_state(state_path) == fixed_now
+
+
+def test_write_dismissed_at_creates_parent_dir(state_path: Path, fixed_now: datetime) -> None:
+    assert not state_path.parent.exists()
+    _write_dismissed_at(state_path, fixed_now)
+    assert state_path.exists()
+    assert _read_dismissed_at(state_path) == fixed_now
+
+
+def test_write_state_preserves_dismissed_at(state_path: Path, fixed_now: datetime) -> None:
+    _write_dismissed_at(state_path, fixed_now)
+    later = fixed_now + timedelta(hours=3)
+    _write_state(state_path, later)
+    assert _read_state(state_path) == later
+    assert _read_dismissed_at(state_path) == fixed_now
+
+
+def test_should_show_hint_suppressed_when_dismissed(state_path: Path, fixed_now: datetime) -> None:
+    _write_dismissed_at(state_path, fixed_now - timedelta(days=30))
+    assert should_show_hint(fixed_now, {}, state_path) is False
+
+
+def test_should_show_hint_dismissed_overrides_window_age(
+    state_path: Path, fixed_now: datetime
+) -> None:
+    """Dismissal suppresses regardless of how long ago it occurred."""
+    _write_dismissed_at(state_path, fixed_now - timedelta(days=365))
+    assert should_show_hint(fixed_now, {}, state_path) is False
+
+
+def test_should_show_hint_after_dismiss_cleared(state_path: Path, fixed_now: datetime) -> None:
+    _write_dismissed_at(state_path, fixed_now - timedelta(hours=1))
+    _write_dismissed_at(state_path, None)
+    assert should_show_hint(fixed_now, {}, state_path) is True
+
+
+def test_set_dismissed_uses_state_path(state_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cloud_hint, "_state_path", lambda: state_path)
+    set_dismissed()
+    assert _read_dismissed_at(state_path) is not None
+
+
+def test_clear_dismissed_uses_state_path(
+    state_path: Path, monkeypatch: pytest.MonkeyPatch, fixed_now: datetime
+) -> None:
+    monkeypatch.setattr(cloud_hint, "_state_path", lambda: state_path)
+    _write_dismissed_at(state_path, fixed_now)
+    clear_dismissed()
+    assert _read_dismissed_at(state_path) is None
+
+
+def test_clear_dismissed_idempotent_when_not_dismissed(
+    state_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(cloud_hint, "_state_path", lambda: state_path)
+    # No prior state — clear should not raise and should leave a clean state.
+    clear_dismissed()
+    assert _read_dismissed_at(state_path) is None
+
+
+def test_maybe_show_hint_suppressed_when_dismissed(
+    state_path: Path, monkeypatch: pytest.MonkeyPatch, fixed_now: datetime
+) -> None:
+    monkeypatch.setattr(cloud_hint, "_state_path", lambda: state_path)
+    monkeypatch.delenv("DOCGLOW_NO_CLOUD_HINT", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    _write_dismissed_at(state_path, fixed_now)
+    console = MagicMock()
+    maybe_show_hint(console, "0.7.3")
+    console.print.assert_not_called()


### PR DESCRIPTION
## Summary

Closes DOC-150.

Prints a single non-intrusive line after a successful `docglow generate` so the ~987 PyPI users/month landing in their terminal can discover Docglow Cloud. Includes UTM attribution so PostHog auto-captures CLI-sourced traffic to `/cloud`, plus user-controlled dismiss surface so engaged users can permanently silence the hint without telemetry or detection.

```
✓ Site generated at ./site/
  Run docglow serve to view locally

💡 Docglow Cloud: hosted docs + AI Q&A + Slack bot → https://docglow.com/cloud?utm_source=cli&utm_medium=cli&utm_campaign=generate&utm_content=v0.7.3
   (run `docglow cloud hide-hint` to dismiss)
```

### Suppression precedence (highest wins)

1. `DOCGLOW_NO_CLOUD_HINT=1` env var
2. `CI=true` env var (auto-suppresses on GH Actions, CircleCI, etc.)
3. `dismissed_at` set via `docglow cloud hide-hint`
4. Shown within last 24h per machine
5. Default — show

### New subcommands

- `docglow cloud hide-hint` — permanently dismiss on this machine
- `docglow cloud show-hint` — re-enable

### Design notes

- **No telemetry, no network calls.** The hint suppression is entirely local. Dismiss state lives in `click.get_app_dir("docglow")/cloud_hint.json` (first use of `click.get_app_dir` in this codebase).
- **All I/O failures swallowed** — the hint must never break `generate`. State-file corruption, permission errors, missing parent dirs, atomic-write failures are all silent.
- **UTM params (not custom keys)** so PostHog and other analytics auto-capture without configuration. Verified live in PostHog after deploying the matching `/cloud` page on www.docglow.com.

Existing top-level `docglow login` / `logout` / `status` / `setup` commands are unchanged. The new `cloud` group contains only the hint-dismiss commands; consolidating the older top-levels under the same group is intentionally out of scope.

## Test plan

- [x] 56 new unit + integration tests covering suppression precedence, state lifecycle, corrupt-file tolerance, dismiss round-trip
- [x] Full pytest suite — 598/598 passing
- [x] ruff lint + format clean
- [x] mypy clean on touched files
- [x] Manual round-trip verified: `cloud hide-hint` → `generate` (silent) → `cloud show-hint` → `generate` (hint reappears)
- [x] `docglow cloud --help` lists both subcommands
- [x] PostHog live-event verification on docglow.com/cloud — UTM params (`utm_source=cli`, `utm_campaign=generate`, `utm_content=v0.7.3`) captured correctly
- [ ] Wait for CI green before merging