### PR TITLE
ci(publish): rebuild frontend from source before packaging wheel

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,9 +13,30 @@ jobs:
     environment: pypi
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Build frontend from source
+        working-directory: frontend
+        run: |
+          npm ci
+          npm run build
+
+      - name: Sync frontend assets into Python package
+        run: |
+          rm -rf src/docglow/static/assets
+          mkdir -p src/docglow/static/assets
+          cp -R frontend/dist/. src/docglow/static/
+
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+
       - run: pip install build
       - run: python -m build
       - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
The publish workflow ran 'python -m build' against whatever was committed under src/docglow/static/, which meant a release could ship a stale frontend bundle if a contributor forgot to run 'npm run build:sync' before tagging. v0.7.0, v0.7.1, and v0.7.2 all shipped the v0.5.4-era bundle for exactly this reason — the multi-model lineage feature (merged for #72) was in the repo but not in the wheel.

Now the publish job runs 'npm ci && npm run build' in frontend/ and copies dist/ into src/docglow/static/ before invoking 'python -m build', making the source tree the only thing that has to be correct at release time. The bundled assets in the repo become a build artifact, not a release input.