### PR TITLE
ci: fail PRs when bundled frontend assets drift from frontend source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,40 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: pip install -e ".[dev,profiling,ai,cloud,column-lineage]"
       - run: pytest --cov=docglow --cov-report=term-missing
+
+  frontend-bundle-drift:
+    name: Frontend bundle drift check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Build frontend from source
+        working-directory: frontend
+        run: |
+          npm ci
+          npm run build
+
+      - name: Sync built assets into src/docglow/static
+        run: |
+          rm -rf src/docglow/static/assets
+          mkdir -p src/docglow/static/assets
+          cp -R frontend/dist/. src/docglow/static/
+
+      - name: Fail if bundled assets drift from frontend source
+        run: |
+          if ! git diff --quiet -- src/docglow/static; then
+            echo "::error::src/docglow/static is out of sync with frontend/src."
+            echo "Run 'npm run build:sync' from frontend/ and commit the result."
+            echo ""
+            echo "Drift detected in:"
+            git diff --name-only -- src/docglow/static
+            exit 1
+          fi
+          echo "Bundled assets match a fresh build from frontend/src."


### PR DESCRIPTION
Adds a frontend-bundle-drift CI job that rebuilds the frontend on every PR and fails if 'git diff src/docglow/static' is non-empty after the sync. This catches the failure mode behind issue #72: the multi-model lineage feature lived in frontend/src/ for three releases (v0.7.0 through v0.7.2) without ever being rebuilt into the bundled assets the wheel ships, so users on those versions could not see the feature.

The companion publish workflow change makes release-time correctness self-healing; this guard keeps PR-time correctness honest so drift cannot silently accumulate between releases either.

