### PR TITLE
chore: release v0.7.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ frontend/test-results/
 .claude/commands/linear.md
 agent-orchestrator.yaml
 test-results/
+.worktrees

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.7.4] - 2026-04-26
+
+### Fixed
+- **Stale frontend bundle in published wheels** — v0.7.0, v0.7.1, and v0.7.2 shipped the v0.5.4-era frontend bundle on PyPI, so the multi-model lineage feature (merged for #72) was missing from the wheel even though the source code was in the repo. Users who upgraded to those versions could not see the feature regardless of cache-clearing. The PyPI publish workflow now rebuilds the frontend from source (`npm ci && npm run build`) and syncs `frontend/dist/` into `src/docglow/static/` before invoking `python -m build`, so `src/docglow/static/` is treated as a build artifact rather than a release input. (#72, #95)
+- **Cloud client follows redirects and supports Vercel protection bypass** — the Cloud `httpx.Client` now sets `follow_redirects=True` and, when `DOCGLOW_VERCEL_BYPASS` is set, attaches `x-vercel-protection-bypass` and `x-vercel-set-bypass-cookie` headers so `docglow publish` works against Vercel-protected preview deployments.
+
 ### Added
-- **Docglow Cloud hint after `docglow generate`** — prints a single non-intrusive line pointing to docglow.com/cloud after a successful generate. Suppress with `DOCGLOW_NO_CLOUD_HINT=1`; auto-suppressed when `CI=true`; rate-limited to once per 24h per machine. Permanently dismiss on this machine with `docglow cloud hide-hint` (and re-enable with `docglow cloud show-hint`).
+- **CI guard against bundled-asset drift** — new `frontend-bundle-drift` CI job rebuilds the frontend on every PR and fails if `src/docglow/static/` differs from a fresh build of `frontend/src/`. Prevents the v0.7.0-v0.7.2 stale-bundle failure mode from silently recurring between releases. (#96)
+- **Docglow Cloud hint after `docglow generate`** — prints a single non-intrusive line pointing to docglow.com/cloud after a successful generate. Suppress with `DOCGLOW_NO_CLOUD_HINT=1`; auto-suppressed when `CI=true`; rate-limited to once per 24h per machine. Permanently dismiss on this machine with `docglow cloud hide-hint` (and re-enable with `docglow cloud show-hint`). (#94)
 
 ## [0.7.3] - 2026-04-22
 

--- a/src/docglow/__init__.py
+++ b/src/docglow/__init__.py
@@ -1,3 +1,3 @@
 """docglow: Next-generation dbt documentation site generator."""
 
-__version__ = "0.7.3"
+__version__ = "0.7.4"

--- a/src/docglow/cloud/client.py
+++ b/src/docglow/cloud/client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from pathlib import Path
 from typing import Any
 
@@ -31,13 +32,19 @@ class CloudClient:
             ) from e
 
         self._config = config
+        headers: dict[str, str] = {
+            "Authorization": f"Bearer {config.token}",
+            "User-Agent": "docglow-cli",
+        }
+        bypass = os.environ.get("DOCGLOW_VERCEL_BYPASS")
+        if bypass:
+            headers["x-vercel-protection-bypass"] = bypass
+            headers["x-vercel-set-bypass-cookie"] = "true"
         self._client = httpx.Client(
             base_url=config.api_base_url,
-            headers={
-                "Authorization": f"Bearer {config.token}",
-                "User-Agent": "docglow-cli",
-            },
+            headers=headers,
             timeout=60.0,
+            follow_redirects=True,
         )
 
     def publish(self, artifacts_path: Path) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

Releases v0.7.4. Includes the publish-workflow fix and CI drift guard that landed earlier in the cycle (#95, #96), the Cloud post-generate hint (#94), and a small Cloud client fix bundled here.

### What ships in v0.7.4

**Fixed**
- **Stale frontend bundle in published wheels** — v0.7.0, v0.7.1, and v0.7.2 shipped the v0.5.4-era bundle on PyPI, so the multi-model lineage feature (#72) was missing from the wheel even though the source was in the repo. Users who upgraded to those versions could not see the feature regardless of cache-clearing. Publish workflow now rebuilds the frontend before packaging. (#72, #95)
- **Cloud client follows redirects and supports Vercel protection bypass** — `httpx.Client` now sets `follow_redirects=True` and, when `DOCGLOW_VERCEL_BYPASS` is set, attaches `x-vercel-protection-bypass` / `x-vercel-set-bypass-cookie` so `docglow publish` works against protected preview deployments.

**Added**
- **CI guard against bundled-asset drift** — new `frontend-bundle-drift` job rebuilds the frontend on every PR and fails if `src/docglow/static/` differs from a fresh build of `frontend/src/`. Closes the loop on the v0.7.0–v0.7.2 failure mode. (#96)
- **Docglow Cloud hint after `docglow generate`** — single-line post-generate hint pointing to docglow.com/cloud. Suppress with `DOCGLOW_NO_CLOUD_HINT=1`, auto-suppressed when `CI=true`, rate-limited to once per 24h, permanently dismissable via `docglow cloud hide-hint`. (#94)

### Commits in this PR

- `a80d4d9` `fix(cloud): follow redirects and support Vercel protection bypass` — split out so it can be `git revert`ed independently of the version bump.
- `de6afb9` `chore: release v0.7.4` — bumps `__version__`, updates CHANGELOG, adds `.worktrees` to `.gitignore`.

## Test plan

- [ ] CI passes (lint, type-check, pytest matrix, and the new `frontend-bundle-drift` job)
- [ ] After merge, tag `v0.7.4` and create the GitHub release; confirm `publish.yml` runs `npm ci && npm run build` before `python -m build`
- [ ] Inspect the published wheel: `pip download docglow==0.7.4 --no-deps && unzip -p docglow-0.7.4-*.whl 'docglow/static/assets/*.js' | grep -c 'pinned models'` should be ≥1
- [ ] Smoke-test on a fresh venv: `pip install docglow==0.7.4`, generate jaffle-shop, open Lineage Explorer, confirm multi-select picker, dbt-selector input, Cmd/Ctrl+Click pin, and Layers filter are all present
- [ ] Verify `docglow cloud hide-hint` and `docglow cloud show-hint` toggle the post-generate banner as documented
- [ ] With `DOCGLOW_VERCEL_BYPASS` unset, confirm `docglow publish` against prod still works (no spurious bypass headers); with it set, confirm a Vercel-protected preview accepts the request

Reply on issue #72 will go out once v0.7.4 is on PyPI.