### PR TITLE
feat(telemetry): opt-in anonymous telemetry CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.7.5] - 2026-05-02
+
+### Added
+- **Opt-in anonymous telemetry** — new `docglow telemetry` subcommand group (`status`, `enable`, `disable`) and a first-run consent prompt on interactive `docglow generate`. Off by default; honors `DOCGLOW_TELEMETRY=1` / `DOCGLOW_NO_TELEMETRY=1` and a `telemetry.enabled` flag in `docglow.yml`. The full payload and privacy contract are documented in [docs/telemetry.md](docs/telemetry.md). (#24)
+- **Telemetry default endpoint** — `https://api.docglow.com/v1/telemetry/events`. Override with `DOCGLOW_TELEMETRY_ENDPOINT` (e.g. for staging at `https://api-staging.docglow.com/v1/telemetry/events`).
+
 ## [0.7.4] - 2026-04-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -243,6 +243,10 @@ repos:
 - A dbt project with `target/manifest.json` (run `dbt compile` or `dbt run` first)
 - See [Compatibility](docs/compatibility.md) for supported dbt versions and adapters
 
+## Telemetry
+
+Docglow has fully opt-in, anonymous telemetry that helps us understand which dbt adapters and project sizes are used in the wild. It is **off by default**, easy to disable with `DOCGLOW_NO_TELEMETRY=1` or `docglow telemetry disable`, and the exact payload is documented at [docs/telemetry.md](docs/telemetry.md).
+
 ## License
 
 MIT

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -126,3 +126,20 @@ That command prints whether telemetry is currently active, your machine-level in
 Events are sent over HTTPS to the Docglow Cloud API at `api.docglow.com`. Rows land in a Postgres table managed via Supabase, accessible only to Docglow maintainers. We retain raw events for 365 days; aggregates may be kept longer.
 
 If you want a particular `instance_id`'s data deleted, open an issue on [docglow/docglow](https://github.com/docglow/docglow/issues) with the ID and we'll purge it.
+
+## Troubleshooting
+
+Telemetry is intentionally fire-and-forget — failures are silent so a flaky network never breaks `docglow generate`. If you've opted in but suspect events aren't landing, set `DOCGLOW_TELEMETRY_DEBUG=1` for one run:
+
+```bash
+DOCGLOW_TELEMETRY_DEBUG=1 docglow generate --project-dir my-project --static
+```
+
+This emits one INFO line per send, e.g.:
+
+```
+telemetry: POST https://api.docglow.com/v1/telemetry/events -> 204
+telemetry: POST https://api.docglow.com/v1/telemetry/events -> failed (Connection refused)
+```
+
+The CLI's exit code is unaffected either way.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,0 +1,128 @@
+# Telemetry
+
+Docglow can send fully anonymous, opt-in telemetry to help us understand which dbt adapters are in use and roughly how big real-world projects are. Telemetry is **off by default** and will not send a single byte until you explicitly enable it.
+
+This page is the canonical reference for what we collect, why, and how to control it.
+
+## Principles
+
+- **Opt-in only.** Default off. We never quietly turn it on.
+- **Anonymous.** No model names, column names, SQL, file paths, project names, credentials, or anything else that could identify you.
+- **Transparent.** This page lists the exact payload. The implementation lives in [`src/docglow/telemetry/`](https://github.com/docglow/docglow/tree/main/src/docglow/telemetry).
+- **Easy to turn off.** A single env var, a config flag, or `docglow telemetry disable`. All three work.
+- **Never breaks your build.** All network and I/O is wrapped to swallow failures. Telemetry can never make `docglow generate` slower than a few milliseconds, hang, or exit non-zero.
+
+## What we collect
+
+When telemetry is enabled, every successful `docglow generate`, `docglow health`, and `docglow serve` startup sends one event with these fields:
+
+```json
+{
+  "schema_version": 1,
+  "instance_id": "5c5a6a39-54bb-4e98-8f3e-5a02e7d7c90e",
+  "command": "generate",
+  "result": "success",
+  "duration_ms": 4218,
+  "docglow_version": "0.7.4",
+  "python_version": "3.12.2",
+  "platform": "linux",
+  "adapter_type": "snowflake",
+  "project_shape": {
+    "models": 142,
+    "sources": 31,
+    "seeds": 4,
+    "tests": 213,
+    "macros": 8
+  },
+  "features_used": ["column_lineage", "static"]
+}
+```
+
+| Field | Why we want it |
+| --- | --- |
+| `schema_version` | Lets us evolve the payload without breaking older CLIs. |
+| `instance_id` | A random UUID4 generated once per machine when you opt in. Lets us count distinct installs without identifying anyone. |
+| `command` | One of `generate`, `health`, `serve`. Tells us which workflows people actually use. |
+| `result` | `success` or `error`. Tells us if a feature is broken in the wild. |
+| `duration_ms` | Performance signal — is `generate` getting slower as we add features? |
+| `docglow_version` | Helps us know how fast users upgrade and whether old versions still need support. |
+| `python_version` / `platform` | Tells us when we can drop a Python version or stop testing a platform. |
+| `adapter_type` | The single most useful field — tells us which dbt adapters to prioritise (Snowflake vs BigQuery vs DuckDB vs Postgres etc). |
+| `project_shape` | Counts only. Lets us understand what "typical" looks like and where to optimise. |
+| `features_used` | Boolean flags only (e.g. `column_lineage`, `static`, `slim`). Tells us which features are loved and which are dead. |
+
+## What we never collect
+
+- Model names, column names, source names, macro names
+- SQL — neither raw nor compiled
+- File paths or directory structure
+- Project names, profile names, schema names
+- API keys, tokens, or credentials of any kind
+- IP addresses, MAC addresses, hostnames, or anything geolocatable
+- Manifest contents, catalog contents, or run results contents
+
+If we ever add a field, it ships in a new `schema_version`, gets documented here, and is reviewed in public on GitHub. There is no path for a field to land silently — the payload builder uses an explicit allow-list ([`src/docglow/telemetry/payload.py`](https://github.com/docglow/docglow/blob/main/src/docglow/telemetry/payload.py)) and the snapshot test pins the exact shape.
+
+## How to enable
+
+Three equivalent ways:
+
+```bash
+docglow telemetry enable
+```
+
+```yaml
+# docglow.yml
+telemetry:
+  enabled: true
+```
+
+```bash
+export DOCGLOW_TELEMETRY=1
+```
+
+The first time you run `docglow generate` on an interactive terminal, you'll see a one-screen prompt asking if you'd like to opt in. The default answer is **no** — pressing enter, running in CI, or running with stdin redirected all keep telemetry off.
+
+## How to disable
+
+Any of these turns telemetry off completely:
+
+```bash
+docglow telemetry disable
+```
+
+```bash
+export DOCGLOW_NO_TELEMETRY=1   # always wins, regardless of other settings
+```
+
+```yaml
+# docglow.yml
+telemetry:
+  enabled: false   # the default
+```
+
+`DOCGLOW_NO_TELEMETRY=1` is the master kill switch. It overrides `DOCGLOW_TELEMETRY=1`, `telemetry: enabled: true` in `docglow.yml`, and any consent recorded by the prompt.
+
+## Resolution order
+
+When deciding whether to send an event, Docglow checks in this order (first match wins):
+
+1. `DOCGLOW_NO_TELEMETRY=1` → off, no matter what.
+2. `DOCGLOW_TELEMETRY=1` (or `=0`) → on (or off).
+3. `telemetry.enabled` in `docglow.yml`.
+4. Recorded consent from the prompt or `docglow telemetry enable`.
+5. Default: off.
+
+To inspect the resolved state on your machine:
+
+```bash
+docglow telemetry status
+```
+
+That command prints whether telemetry is currently active, your machine-level instance ID, the endpoint, and which env vars are set.
+
+## Where the data goes
+
+Events are sent over HTTPS to the Docglow Cloud API at `api.docglow.dev`. Rows land in a Postgres table managed via Supabase, accessible only to Docglow maintainers. We retain raw events for 365 days; aggregates may be kept longer.
+
+If you want a particular `instance_id`'s data deleted, open an issue on [docglow/docglow](https://github.com/docglow/docglow/issues) with the ID and we'll purge it.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -123,6 +123,6 @@ That command prints whether telemetry is currently active, your machine-level in
 
 ## Where the data goes
 
-Events are sent over HTTPS to the Docglow Cloud API at `api.docglow.dev`. Rows land in a Postgres table managed via Supabase, accessible only to Docglow maintainers. We retain raw events for 365 days; aggregates may be kept longer.
+Events are sent over HTTPS to the Docglow Cloud API at `api.docglow.com`. Rows land in a Postgres table managed via Supabase, accessible only to Docglow maintainers. We retain raw events for 365 days; aggregates may be kept longer.
 
 If you want a particular `instance_id`'s data deleted, open an issue on [docglow/docglow](https://github.com/docglow/docglow/issues) with the ID and we'll purge it.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,4 +82,5 @@ nav:
   - Reference:
     - CLI Commands: reference/cli.md
     - Compatibility: compatibility.md
+    - Telemetry: telemetry.md
   - Cloud: cloud.md

--- a/src/docglow/__init__.py
+++ b/src/docglow/__init__.py
@@ -1,3 +1,3 @@
 """docglow: Next-generation dbt documentation site generator."""
 
-__version__ = "0.7.4"
+__version__ = "0.7.5"

--- a/src/docglow/cli.py
+++ b/src/docglow/cli.py
@@ -15,6 +15,7 @@ from docglow.commands.mcp import mcp_server
 from docglow.commands.profile import profile
 from docglow.commands.publish import publish
 from docglow.commands.serve import serve
+from docglow.commands.telemetry import telemetry as telemetry_group
 
 console = Console()
 
@@ -57,3 +58,4 @@ cli.add_command(setup)
 cli.add_command(cloud_group)
 cli.add_command(mcp_server)
 cli.add_command(init)
+cli.add_command(telemetry_group)

--- a/src/docglow/commands/generate.py
+++ b/src/docglow/commands/generate.py
@@ -1,5 +1,6 @@
 """Generate command for docglow CLI."""
 
+import time
 from pathlib import Path
 
 import click
@@ -162,6 +163,25 @@ def generate(
     if profile and profile_adapter and profile_connection:
         profiling_connection = _parse_connection(profile_adapter, profile_connection)
 
+    # Telemetry setup -- dispatched in the finally block so success/error and
+    # duration are recorded regardless of how the command exits.
+    from docglow.telemetry import dispatcher as telemetry
+
+    telemetry_started = time.monotonic()
+    telemetry_features: list[str] = []
+    if column_lineage:
+        telemetry_features.append("column_lineage")
+    if profile:
+        telemetry_features.append("profiling")
+    if ai:
+        telemetry_features.append("ai_chat")
+    if static:
+        telemetry_features.append("static")
+    if slim:
+        telemetry_features.append("slim")
+    telemetry_resolved_target = target_dir or (project_dir / "target")
+    telemetry_result_name = "error"
+
     try:
         output_path, health_score = generate_site(
             project_dir=project_dir,
@@ -205,9 +225,19 @@ def generate(
                 )
 
         maybe_show_hint(console, __version__)
+        telemetry_result_name = "success"
     except ArtifactLoadError as e:
         console.print(f"[bold red]Error:[/bold red] {e}")
         raise SystemExit(1) from e
     except FileNotFoundError as e:
         console.print(f"[bold red]Error:[/bold red] {e}")
         raise SystemExit(1) from e
+    finally:
+        telemetry.record_command(
+            config.telemetry,
+            command="generate",
+            result=telemetry_result_name,  # type: ignore[arg-type]
+            duration_ms=int((time.monotonic() - telemetry_started) * 1000),
+            project_shape=telemetry.project_shape_from_manifest_path(telemetry_resolved_target),
+            features_used=tuple(telemetry_features),
+        )

--- a/src/docglow/commands/generate.py
+++ b/src/docglow/commands/generate.py
@@ -164,8 +164,13 @@ def generate(
         profiling_connection = _parse_connection(profile_adapter, profile_connection)
 
     # Telemetry setup -- dispatched in the finally block so success/error and
-    # duration are recorded regardless of how the command exits.
+    # duration are recorded regardless of how the command exits. The first-run
+    # consent prompt fires here (before the long generate work) when the
+    # context is interactive and consent has not yet been recorded.
+    from docglow.commands.telemetry import maybe_prompt_for_consent
     from docglow.telemetry import dispatcher as telemetry
+
+    maybe_prompt_for_consent(console)
 
     telemetry_started = time.monotonic()
     telemetry_features: list[str] = []

--- a/src/docglow/commands/health.py
+++ b/src/docglow/commands/health.py
@@ -1,5 +1,6 @@
 """Health command for docglow CLI."""
 
+import time
 from pathlib import Path
 
 import click
@@ -35,137 +36,159 @@ def health(
 
     from docglow.artifacts.loader import ArtifactLoadError, load_artifacts
     from docglow.cli import console
+    from docglow.config import load_config
     from docglow.generator.data import build_docglow_data
+    from docglow.telemetry import dispatcher as telemetry
+
+    config = load_config(project_dir)
+    telemetry_started = time.monotonic()
+    telemetry_result_name = "error"
+    telemetry_manifest = None
 
     try:
-        artifacts = load_artifacts(project_dir, target_dir)
-    except ArtifactLoadError as e:
-        console.print(f"[bold red]Error:[/bold red] {e}")
-        raise SystemExit(1) from e
+        try:
+            artifacts = load_artifacts(project_dir, target_dir)
+        except ArtifactLoadError as e:
+            console.print(f"[bold red]Error:[/bold red] {e}")
+            raise SystemExit(1) from e
 
-    # Build data to get transformed models/sources
-    data = build_docglow_data(artifacts)
-    health_data = data["health"]
-    score = health_data["score"]
+        telemetry_manifest = artifacts.manifest
 
-    if output_format == "json":
-        console.print(json.dumps(health_data, indent=2))
-        if fail_under is not None and score["overall"] < fail_under:
-            console.print(
-                f"\n[bold red]Health score {score['overall']:.0f} is below "
-                f"threshold {fail_under:.0f}[/bold red]"
-            )
-            raise SystemExit(1)
-        return
+        # Build data to get transformed models/sources
+        data = build_docglow_data(artifacts)
+        health_data = data["health"]
+        score = health_data["score"]
 
-    if output_format == "markdown":
-        lines = [
-            "## Docglow Health Report\n",
-            "| Category | Score |",
-            "|----------|-------|",
-            f"| **Overall** | **{score['overall']:.0f}/100 ({score['grade']})** |",
-            f"| Documentation | {score['documentation']:.0f} |",
-            f"| Testing | {score['testing']:.0f} |",
-            f"| Freshness | {score['freshness']:.0f} |",
-            f"| Complexity | {score['complexity']:.0f} |",
-            f"| Naming | {score['naming']:.0f} |",
-            f"| Orphans | {score['orphans']:.0f} |",
-        ]
+        if output_format == "json":
+            console.print(json.dumps(health_data, indent=2))
+            if fail_under is not None and score["overall"] < fail_under:
+                console.print(
+                    f"\n[bold red]Health score {score['overall']:.0f} is below "
+                    f"threshold {fail_under:.0f}[/bold red]"
+                )
+                raise SystemExit(1)
+            telemetry_result_name = "success"
+            return
 
-        undoc = health_data["coverage"].get("undocumented_models", [])
-        if undoc:
-            top = sorted(
-                undoc,
-                key=lambda x: x.get("downstream_count", 0),
-                reverse=True,
-            )[0]
-            lines.append(
-                f"\n**{len(undoc)} undocumented model{'s' if len(undoc) != 1 else ''}** "
-                f"(highest impact: `{top['name']}` with "
-                f"{top.get('downstream_count', 0)} downstream dependents)"
-            )
+        if output_format == "markdown":
+            lines = [
+                "## Docglow Health Report\n",
+                "| Category | Score |",
+                "|----------|-------|",
+                f"| **Overall** | **{score['overall']:.0f}/100 ({score['grade']})** |",
+                f"| Documentation | {score['documentation']:.0f} |",
+                f"| Testing | {score['testing']:.0f} |",
+                f"| Freshness | {score['freshness']:.0f} |",
+                f"| Complexity | {score['complexity']:.0f} |",
+                f"| Naming | {score['naming']:.0f} |",
+                f"| Orphans | {score['orphans']:.0f} |",
+            ]
 
-        naming_violations = health_data["naming"].get("violations", [])
-        if naming_violations:
-            count = len(naming_violations)
-            lines.append(f"**{count} naming violation{'s' if count != 1 else ''}**")
+            undoc = health_data["coverage"].get("undocumented_models", [])
+            if undoc:
+                top = sorted(
+                    undoc,
+                    key=lambda x: x.get("downstream_count", 0),
+                    reverse=True,
+                )[0]
+                lines.append(
+                    f"\n**{len(undoc)} undocumented model{'s' if len(undoc) != 1 else ''}** "
+                    f"(highest impact: `{top['name']}` with "
+                    f"{top.get('downstream_count', 0)} downstream dependents)"
+                )
 
-        orphans = health_data["orphans"]
-        if orphans:
-            count = len(orphans)
-            lines.append(f"**{count} orphan model{'s' if count != 1 else ''}**")
+            naming_violations = health_data["naming"].get("violations", [])
+            if naming_violations:
+                count = len(naming_violations)
+                lines.append(f"**{count} naming violation{'s' if count != 1 else ''}**")
 
-        click.echo("\n".join(lines))
+            orphans = health_data["orphans"]
+            if orphans:
+                count = len(orphans)
+                lines.append(f"**{count} orphan model{'s' if count != 1 else ''}**")
 
-        if fail_under is not None and score["overall"] < fail_under:
-            console.print(
-                f"\n[bold red]Health score {score['overall']:.0f} is below "
-                f"threshold {fail_under:.0f}[/bold red]"
-            )
-            raise SystemExit(1)
-        return
+            click.echo("\n".join(lines))
 
-    # Table output
-    grade_color = {
-        "A": "green",
-        "B": "blue",
-        "C": "yellow",
-        "D": "red",
-        "F": "bold red",
-    }.get(score["grade"], "white")
+            if fail_under is not None and score["overall"] < fail_under:
+                console.print(
+                    f"\n[bold red]Health score {score['overall']:.0f} is below "
+                    f"threshold {fail_under:.0f}[/bold red]"
+                )
+                raise SystemExit(1)
+            telemetry_result_name = "success"
+            return
 
-    console.print()
-    console.print("[bold]docglow Project Health[/bold]")
-    overall = f"{score['overall']:.0f}/100 ({score['grade']})"
-    console.print(f"  Overall Score: [{grade_color}]{overall}[/{grade_color}]")
-    console.print()
+        # Table output
+        grade_color = {
+            "A": "green",
+            "B": "blue",
+            "C": "yellow",
+            "D": "red",
+            "F": "bold red",
+        }.get(score["grade"], "white")
 
-    table = Table(show_header=True, header_style="bold")
-    table.add_column("Category", style="bold")
-    table.add_column("Score", justify="right")
-    table.add_column("Details")
+        console.print()
+        console.print("[bold]docglow Project Health[/bold]")
+        overall = f"{score['overall']:.0f}/100 ({score['grade']})"
+        console.print(f"  Overall Score: [{grade_color}]{overall}[/{grade_color}]")
+        console.print()
 
-    cov = health_data["coverage"]
-    table.add_row(
-        "Documentation",
-        f"{score['documentation']:.0f}",
-        f"Models: {cov['models_documented']['covered']}/{cov['models_documented']['total']}  "
-        f"Columns: {cov['columns_documented']['covered']}/{cov['columns_documented']['total']}",
-    )
-    table.add_row(
-        "Testing",
-        f"{score['testing']:.0f}",
-        f"Models: {cov['models_tested']['covered']}/{cov['models_tested']['total']}  "
-        f"Columns: {cov['columns_tested']['covered']}/{cov['columns_tested']['total']}",
-    )
-    table.add_row(
-        "Source Freshness",
-        f"{score['freshness']:.0f}",
-        "No monitored sources" if score["freshness"] == 100.0 else "",
-    )
-    table.add_row(
-        "Model Complexity",
-        f"{score['complexity']:.0f}",
-        f"{health_data['complexity']['high_count']} high-complexity models",
-    )
-    table.add_row(
-        "Naming Conventions",
-        f"{score['naming']:.0f}",
-        f"{health_data['naming']['compliant_count']}"
-        f"/{health_data['naming']['total_checked']} compliant",
-    )
-    table.add_row(
-        "Orphan Detection",
-        f"{score['orphans']:.0f}",
-        f"{len(health_data['orphans'])} orphan models",
-    )
+        table = Table(show_header=True, header_style="bold")
+        table.add_column("Category", style="bold")
+        table.add_column("Score", justify="right")
+        table.add_column("Details")
 
-    console.print(table)
-    console.print()
-
-    if fail_under is not None and score["overall"] < fail_under:
-        console.print(
-            f"\n[bold red]Health score {score['overall']:.0f} is below "
-            f"threshold {fail_under:.0f}[/bold red]"
+        cov = health_data["coverage"]
+        table.add_row(
+            "Documentation",
+            f"{score['documentation']:.0f}",
+            f"Models: {cov['models_documented']['covered']}/{cov['models_documented']['total']}  "
+            f"Columns: {cov['columns_documented']['covered']}/{cov['columns_documented']['total']}",
         )
-        raise SystemExit(1)
+        table.add_row(
+            "Testing",
+            f"{score['testing']:.0f}",
+            f"Models: {cov['models_tested']['covered']}/{cov['models_tested']['total']}  "
+            f"Columns: {cov['columns_tested']['covered']}/{cov['columns_tested']['total']}",
+        )
+        table.add_row(
+            "Source Freshness",
+            f"{score['freshness']:.0f}",
+            "No monitored sources" if score["freshness"] == 100.0 else "",
+        )
+        table.add_row(
+            "Model Complexity",
+            f"{score['complexity']:.0f}",
+            f"{health_data['complexity']['high_count']} high-complexity models",
+        )
+        table.add_row(
+            "Naming Conventions",
+            f"{score['naming']:.0f}",
+            f"{health_data['naming']['compliant_count']}"
+            f"/{health_data['naming']['total_checked']} compliant",
+        )
+        table.add_row(
+            "Orphan Detection",
+            f"{score['orphans']:.0f}",
+            f"{len(health_data['orphans'])} orphan models",
+        )
+
+        console.print(table)
+        console.print()
+
+        if fail_under is not None and score["overall"] < fail_under:
+            console.print(
+                f"\n[bold red]Health score {score['overall']:.0f} is below "
+                f"threshold {fail_under:.0f}[/bold red]"
+            )
+            raise SystemExit(1)
+        telemetry_result_name = "success"
+    finally:
+        telemetry.record_command(
+            config.telemetry,
+            command="health",
+            result=telemetry_result_name,  # type: ignore[arg-type]
+            duration_ms=int((time.monotonic() - telemetry_started) * 1000),
+            manifest=telemetry_manifest,
+            features_used=(output_format,),
+        )

--- a/src/docglow/commands/serve.py
+++ b/src/docglow/commands/serve.py
@@ -69,6 +69,24 @@ def serve(
         console.print("  Verbose: request logging enabled")
     console.print("  Press [bold]Ctrl+C[/bold] to stop\n")
 
+    # Telemetry: emit at startup -- a serve session may run for hours and a
+    # shutdown event would be lost on Ctrl+C. We record startup as "success"
+    # because the server is about to start blocking; failure to start would
+    # raise inside start_server below.
+    from docglow.config import load_config
+    from docglow.telemetry import dispatcher as telemetry
+
+    serve_config = load_config(project_dir)
+    telemetry_features: tuple[str, ...] = ("watch",) if watch else ()
+    telemetry.record_command(
+        serve_config.telemetry,
+        command="serve",
+        result="success",
+        duration_ms=0,
+        project_shape=telemetry.project_shape_from_manifest_path(project_dir / "target"),
+        features_used=telemetry_features,
+    )
+
     if watch:
         from docglow.server.watcher import start_watcher
 

--- a/src/docglow/commands/telemetry.py
+++ b/src/docglow/commands/telemetry.py
@@ -1,0 +1,128 @@
+"""``docglow telemetry`` -- inspect and toggle telemetry consent.
+
+The CLI surface that lets users see exactly what telemetry will do and
+control it without editing config files. Output is the canonical reference
+for "what is the resolved state" -- the same logic the dispatcher uses.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import click
+
+from docglow.telemetry import state
+from docglow.telemetry.config import (
+    ENV_ENDPOINT_OVERRIDE,
+    ENV_OPT_IN,
+    ENV_OPT_OUT,
+    resolve_telemetry_config,
+)
+from docglow.telemetry.dispatcher import is_active
+
+DOCS_URL = "https://docs.docglow.com/telemetry"
+
+
+@click.group()
+def telemetry() -> None:
+    """Inspect and control opt-in anonymous telemetry."""
+
+
+@telemetry.command()
+def status() -> None:
+    """Show the current telemetry state."""
+    config = resolve_telemetry_config(None)
+    consent = state.get_consent()
+    instance_id = state.get_instance_id()
+    active = is_active(config, consent)
+
+    click.echo("docglow telemetry status")
+    click.echo("------------------------")
+    click.echo(f"  Active: {'yes' if active else 'no'}")
+    click.echo(f"  Instance ID: {instance_id}")
+    click.echo(f"  Endpoint: {config.endpoint}")
+    click.echo(f"  Recorded consent: {consent}")
+    click.echo()
+    click.echo("Resolution:")
+    click.echo(f"  {ENV_OPT_OUT}: {os.environ.get(ENV_OPT_OUT, '(unset)')}")
+    click.echo(f"  {ENV_OPT_IN}: {os.environ.get(ENV_OPT_IN, '(unset)')}")
+    click.echo(f"  {ENV_ENDPOINT_OVERRIDE}: {os.environ.get(ENV_ENDPOINT_OVERRIDE, '(unset)')}")
+    click.echo()
+    click.echo(f"What is collected: {DOCS_URL}")
+
+
+@telemetry.command()
+def enable() -> None:
+    """Opt in to anonymous telemetry."""
+    state.set_consent("yes")
+    click.echo("Anonymous telemetry enabled.")
+    click.echo(f"What is collected: {DOCS_URL}")
+    click.echo("Disable anytime with `docglow telemetry disable` or DOCGLOW_NO_TELEMETRY=1.")
+
+
+@telemetry.command()
+def disable() -> None:
+    """Opt out of telemetry."""
+    state.set_consent("no")
+    click.echo("Telemetry disabled. No events will be sent.")
+
+
+def _can_prompt() -> bool:
+    """Return True iff we're in an interactive context where prompting is appropriate."""
+    if os.environ.get("CI", "").strip().lower() in {"1", "true", "yes", "on"}:
+        return False
+    if os.environ.get(ENV_OPT_OUT):
+        # Don't prompt if the user has already forced telemetry off via env.
+        return False
+    try:
+        return sys.stdin.isatty() and sys.stdout.isatty()
+    except Exception:
+        return False
+
+
+PROMPT_MESSAGE = (
+    "\n[bold]Help improve docglow with anonymous telemetry?[/bold]\n"
+    "We collect counts (models, sources, tests) and your dbt adapter type "
+    "to prioritise features.\n"
+    f"Full details: {DOCS_URL}\n"
+    "  - No model names, column names, SQL, file paths, or credentials.\n"
+    "  - Disable anytime with `docglow telemetry disable` or "
+    "[bold]DOCGLOW_NO_TELEMETRY=1[/bold].\n"
+)
+
+
+def maybe_prompt_for_consent(console=None) -> state.ConsentValue:
+    """Prompt the user for telemetry consent if appropriate, return resolved value.
+
+    Returns the recorded consent ("yes", "no", or "unset"). Records "no"
+    automatically when the prompt is suppressed -- this means we never
+    prompt twice and never block non-interactive runs.
+
+    Pass ``console`` (a rich Console) to render styled output; falls back to
+    plain ``click.echo`` if missing or rendering fails. Never raises.
+    """
+    try:
+        current = state.get_consent()
+        if current != "unset":
+            return current
+
+        if not _can_prompt():
+            # Record an implicit "no" so we never re-prompt this user.
+            state.set_consent("no")
+            return "no"
+
+        try:
+            if console is not None:
+                console.print(PROMPT_MESSAGE)
+            else:
+                click.echo(PROMPT_MESSAGE)
+            answer = click.confirm("Enable anonymous telemetry?", default=False)
+        except Exception:
+            answer = False
+
+        consent: state.ConsentValue = "yes" if answer else "no"
+        state.set_consent(consent)
+        return consent
+    except Exception:
+        return "unset"

--- a/src/docglow/commands/telemetry.py
+++ b/src/docglow/commands/telemetry.py
@@ -92,7 +92,7 @@ PROMPT_MESSAGE = (
 )
 
 
-def maybe_prompt_for_consent(console=None) -> state.ConsentValue:
+def maybe_prompt_for_consent(console: object | None = None) -> state.ConsentValue:
     """Prompt the user for telemetry consent if appropriate, return resolved value.
 
     Returns the recorded consent ("yes", "no", or "unset"). Records "no"
@@ -113,7 +113,7 @@ def maybe_prompt_for_consent(console=None) -> state.ConsentValue:
             return "no"
 
         try:
-            if console is not None:
+            if console is not None and hasattr(console, "print"):
                 console.print(PROMPT_MESSAGE)
             else:
                 click.echo(PROMPT_MESSAGE)

--- a/src/docglow/config.py
+++ b/src/docglow/config.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from docglow.generator.layers import LineageLayerConfig, parse_layer_config
+from docglow.telemetry.config import TelemetryConfig, resolve_telemetry_config
 
 logger = logging.getLogger(__name__)
 
@@ -114,6 +115,7 @@ class DocglowConfig:
     slim: bool = False
     column_lineage: bool = True
     lineage_layers: LineageLayerConfig = field(default_factory=LineageLayerConfig)
+    telemetry: TelemetryConfig = field(default_factory=TelemetryConfig)
 
     # Runtime paths (not from config file)
     project_dir: Path = field(default_factory=lambda: Path("."))
@@ -132,7 +134,8 @@ def load_config(project_dir: Path) -> DocglowConfig:
             logger.info("Loading config from %s", config_path)
             return _parse_config_file(config_path)
 
-    return DocglowConfig()
+    # No yml file: env vars can still toggle telemetry, so resolve from env.
+    return DocglowConfig(telemetry=resolve_telemetry_config(None))
 
 
 def _parse_config_file(path: Path) -> DocglowConfig:
@@ -271,6 +274,8 @@ def _build_config_from_dict(raw: dict[str, Any]) -> DocglowConfig:
 
     ui = _build_ui_config(raw.get("ui", {}))
 
+    telemetry = resolve_telemetry_config(raw.get("telemetry"))
+
     return DocglowConfig(
         version=raw.get("version", 1),
         title=raw.get("title", "docglow"),
@@ -283,6 +288,7 @@ def _build_config_from_dict(raw: dict[str, Any]) -> DocglowConfig:
         insights=insights,
         ui=ui,
         lineage_layers=lineage_layers,
+        telemetry=telemetry,
     )
 
 

--- a/src/docglow/telemetry/__init__.py
+++ b/src/docglow/telemetry/__init__.py
@@ -1,0 +1,14 @@
+"""Opt-in anonymous telemetry for docglow.
+
+This package implements the CLI side of the telemetry pipeline described in
+GitHub issue #24 and the implementation plan
+``docglow-private-docs/planning/2026-04-29-001-feat-opt-in-telemetry-plan.md``.
+
+Discipline mirrors :mod:`docglow.cloud_hint`: every code path here must be
+safe to run in any environment, must never raise into a calling CLI command,
+and must default to *no* network activity until the user explicitly opts in.
+"""
+
+from docglow.telemetry.config import TelemetryConfig, resolve_telemetry_config
+
+__all__ = ["TelemetryConfig", "resolve_telemetry_config"]

--- a/src/docglow/telemetry/client.py
+++ b/src/docglow/telemetry/client.py
@@ -22,14 +22,55 @@ import atexit
 import json
 import logging
 import os
+import sys
 import threading
 import urllib.error
 import urllib.request
 from collections.abc import Mapping
+from typing import Any
 
 import docglow as _docglow
 
 logger = logging.getLogger(__name__)
+
+
+class _PostPreservingRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Follow 301/302/303/307/308 redirects while preserving POST body and headers.
+
+    The stdlib default raises ``HTTPError`` on POST + 307/308 -- which is
+    technically more conservative than RFC 7231 requires and breaks against
+    Vercel routes that issue 307s for host/path canonicalization. Mirrors
+    httpx's ``follow_redirects=True`` behaviour used by the cloud client.
+    """
+
+    def redirect_request(
+        self,
+        req: urllib.request.Request,
+        fp: Any,
+        code: int,
+        msg: str,
+        headers: Any,
+        newurl: str,
+    ) -> urllib.request.Request | None:
+        if code not in (301, 302, 303, 307, 308):
+            return None
+        # 303 always degrades to GET per RFC. 301/302/307/308 keep the method
+        # (some clients downgrade 301/302 POST -> GET, but Vercel and modern
+        # tooling preserve method; we follow that convention).
+        new_method = "GET" if code == 303 else req.get_method()
+        new_data = None if new_method == "GET" else req.data
+        new_headers = {k: v for k, v in req.header_items() if k.lower() != "host"}
+        return urllib.request.Request(
+            newurl,
+            data=new_data,
+            headers=new_headers,
+            origin_req_host=req.origin_req_host,
+            unverifiable=True,
+            method=new_method,
+        )
+
+
+_opener = urllib.request.build_opener(_PostPreservingRedirectHandler())
 
 DEFAULT_TIMEOUT_SECONDS = 2.0
 USER_AGENT = f"docglow-cli-telemetry/{_docglow.__version__}"
@@ -110,6 +151,22 @@ def _build_request(
     )
 
 
+def _diag(message: str) -> None:
+    """Write a debug-mode diagnostic to stderr, bypassing any logging config.
+
+    The ``logger.info()`` path is unreliable across CLI commands because
+    different commands configure docglow's loggers at different levels.
+    Users who set ``DOCGLOW_TELEMETRY_DEBUG=1`` have explicitly asked to see
+    these lines; print them directly so visibility doesn't depend on which
+    subcommand happened to bump the log level.
+    """
+    try:
+        print(message, file=sys.stderr, flush=True)
+    except Exception:
+        # Even a closed stderr must not propagate.
+        pass
+
+
 def send_sync(
     payload: dict[str, object],
     endpoint: str,
@@ -119,27 +176,28 @@ def send_sync(
     """POST the payload synchronously. Returns True on 2xx, False otherwise.
 
     Never raises. Exceptions are caught and logged at DEBUG. When
-    ``DOCGLOW_TELEMETRY_DEBUG`` is truthy, also emits an INFO line per send
-    so users can self-diagnose "why aren't my events showing up?".
+    ``DOCGLOW_TELEMETRY_DEBUG`` is truthy, also writes a one-line diagnostic
+    to stderr per send so users can self-diagnose "why aren't my events
+    showing up?".
     """
     environ = env if env is not None else os.environ
     debug = _is_debug(environ)
     try:
         request = _build_request(payload, endpoint, environ)
-        with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310
+        with _opener.open(request, timeout=timeout) as response:  # noqa: S310
             ok = bool(200 <= response.status < 300)
             if debug:
-                logger.info("telemetry: POST %s -> %s", endpoint, response.status)
+                _diag(f"telemetry: POST {endpoint} -> {response.status}")
             return ok
     except urllib.error.HTTPError as exc:
         logger.debug("telemetry: HTTP %s from %s", exc.code, endpoint)
         if debug:
-            logger.info("telemetry: POST %s -> %s (HTTPError)", endpoint, exc.code)
+            _diag(f"telemetry: POST {endpoint} -> {exc.code} (HTTPError)")
         return False
     except Exception as exc:
         logger.debug("telemetry: send failed: %s", exc)
         if debug:
-            logger.info("telemetry: POST %s -> failed (%s)", endpoint, exc)
+            _diag(f"telemetry: POST {endpoint} -> failed ({exc})")
         return False
 
 

--- a/src/docglow/telemetry/client.py
+++ b/src/docglow/telemetry/client.py
@@ -60,6 +60,11 @@ class _PostPreservingRedirectHandler(urllib.request.HTTPRedirectHandler):
         new_method = "GET" if code == 303 else req.get_method()
         new_data = None if new_method == "GET" else req.data
         new_headers = {k: v for k, v in req.header_items() if k.lower() != "host"}
+        if _is_debug(os.environ):
+            _diag(
+                f"telemetry: redirect {code} {req.get_method()} {req.full_url} "
+                f"-> {new_method} {newurl}"
+            )
         return urllib.request.Request(
             newurl,
             data=new_data,

--- a/src/docglow/telemetry/client.py
+++ b/src/docglow/telemetry/client.py
@@ -20,9 +20,11 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import threading
 import urllib.error
 import urllib.request
+from collections.abc import Mapping
 
 import docglow as _docglow
 
@@ -31,16 +33,33 @@ logger = logging.getLogger(__name__)
 DEFAULT_TIMEOUT_SECONDS = 2.0
 USER_AGENT = f"docglow-cli-telemetry/{_docglow.__version__}"
 
+ENV_VERCEL_BYPASS = "DOCGLOW_VERCEL_BYPASS"
+ENV_DEBUG = "DOCGLOW_TELEMETRY_DEBUG"
 
-def _build_request(payload: dict[str, object], endpoint: str) -> urllib.request.Request:
+
+def _is_debug(env: Mapping[str, str]) -> bool:
+    value = env.get(ENV_DEBUG, "").strip().lower()
+    return value in {"1", "true", "yes", "on"}
+
+
+def _build_request(
+    payload: dict[str, object],
+    endpoint: str,
+    env: Mapping[str, str],
+) -> urllib.request.Request:
     body = json.dumps(payload).encode("utf-8")
+    headers: dict[str, str] = {
+        "Content-Type": "application/json",
+        "User-Agent": USER_AGENT,
+    }
+    bypass = env.get(ENV_VERCEL_BYPASS)
+    if bypass:
+        headers["x-vercel-protection-bypass"] = bypass
+        headers["x-vercel-set-bypass-cookie"] = "true"
     return urllib.request.Request(
         url=endpoint,
         data=body,
-        headers={
-            "Content-Type": "application/json",
-            "User-Agent": USER_AGENT,
-        },
+        headers=headers,
         method="POST",
     )
 
@@ -49,20 +68,32 @@ def send_sync(
     payload: dict[str, object],
     endpoint: str,
     timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    env: Mapping[str, str] | None = None,
 ) -> bool:
     """POST the payload synchronously. Returns True on 2xx, False otherwise.
 
-    Never raises. Exceptions are caught and logged at DEBUG.
+    Never raises. Exceptions are caught and logged at DEBUG. When
+    ``DOCGLOW_TELEMETRY_DEBUG`` is truthy, also emits an INFO line per send
+    so users can self-diagnose "why aren't my events showing up?".
     """
+    environ = env if env is not None else os.environ
+    debug = _is_debug(environ)
     try:
-        request = _build_request(payload, endpoint)
+        request = _build_request(payload, endpoint, environ)
         with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310
-            return bool(200 <= response.status < 300)
+            ok = bool(200 <= response.status < 300)
+            if debug:
+                logger.info("telemetry: POST %s -> %s", endpoint, response.status)
+            return ok
     except urllib.error.HTTPError as exc:
         logger.debug("telemetry: HTTP %s from %s", exc.code, endpoint)
+        if debug:
+            logger.info("telemetry: POST %s -> %s (HTTPError)", endpoint, exc.code)
         return False
     except Exception as exc:
         logger.debug("telemetry: send failed: %s", exc)
+        if debug:
+            logger.info("telemetry: POST %s -> failed (%s)", endpoint, exc)
         return False
 
 

--- a/src/docglow/telemetry/client.py
+++ b/src/docglow/telemetry/client.py
@@ -57,7 +57,7 @@ def send_sync(
     try:
         request = _build_request(payload, endpoint)
         with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310
-            return 200 <= response.status < 300
+            return bool(200 <= response.status < 300)
     except urllib.error.HTTPError as exc:
         logger.debug("telemetry: HTTP %s from %s", exc.code, endpoint)
         return False

--- a/src/docglow/telemetry/client.py
+++ b/src/docglow/telemetry/client.py
@@ -1,0 +1,88 @@
+"""Fire-and-forget HTTP transport for telemetry events.
+
+Uses ``urllib.request`` rather than ``httpx`` so telemetry works without the
+``[cloud]`` extras -- a user who explicitly opts in shouldn't be told to
+install another package first.
+
+Two entry points:
+
+- :func:`send` -- fire-and-forget on a daemon thread. The default in
+  production code paths. Returns immediately; the caller never observes
+  the network at all.
+- :func:`send_sync` -- synchronous, blocking. For tests and the dispatcher's
+  internal verification path.
+
+Both swallow every exception. The cost of a missed event is zero; the cost
+of a hung or crashing CLI is significant.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import urllib.error
+import urllib.request
+
+import docglow as _docglow
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TIMEOUT_SECONDS = 2.0
+USER_AGENT = f"docglow-cli-telemetry/{_docglow.__version__}"
+
+
+def _build_request(payload: dict[str, object], endpoint: str) -> urllib.request.Request:
+    body = json.dumps(payload).encode("utf-8")
+    return urllib.request.Request(
+        url=endpoint,
+        data=body,
+        headers={
+            "Content-Type": "application/json",
+            "User-Agent": USER_AGENT,
+        },
+        method="POST",
+    )
+
+
+def send_sync(
+    payload: dict[str, object],
+    endpoint: str,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+) -> bool:
+    """POST the payload synchronously. Returns True on 2xx, False otherwise.
+
+    Never raises. Exceptions are caught and logged at DEBUG.
+    """
+    try:
+        request = _build_request(payload, endpoint)
+        with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310
+            return 200 <= response.status < 300
+    except urllib.error.HTTPError as exc:
+        logger.debug("telemetry: HTTP %s from %s", exc.code, endpoint)
+        return False
+    except Exception as exc:
+        logger.debug("telemetry: send failed: %s", exc)
+        return False
+
+
+def send(
+    payload: dict[str, object],
+    endpoint: str,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+) -> None:
+    """Fire-and-forget: POST on a daemon thread. Never raises, never blocks.
+
+    The thread is daemonised so process shutdown does not wait for it.
+    """
+    try:
+        thread = threading.Thread(
+            target=send_sync,
+            args=(payload, endpoint, timeout),
+            name="docglow-telemetry",
+            daemon=True,
+        )
+        thread.start()
+    except Exception as exc:
+        # Even thread-creation failures must not propagate.
+        logger.debug("telemetry: thread spawn failed: %s", exc)

--- a/src/docglow/telemetry/client.py
+++ b/src/docglow/telemetry/client.py
@@ -18,6 +18,7 @@ of a hung or crashing CLI is significant.
 
 from __future__ import annotations
 
+import atexit
 import json
 import logging
 import os
@@ -35,6 +36,51 @@ USER_AGENT = f"docglow-cli-telemetry/{_docglow.__version__}"
 
 ENV_VERCEL_BYPASS = "DOCGLOW_VERCEL_BYPASS"
 ENV_DEBUG = "DOCGLOW_TELEMETRY_DEBUG"
+
+# Bounded total wait at process exit, regardless of how many sends are in flight.
+# Each individual send still has its own timeout enforced by urlopen.
+_ATEXIT_BUDGET_SECONDS = 2.5
+
+_pending_lock = threading.Lock()
+_pending_threads: list[threading.Thread] = []
+_atexit_registered = False
+
+
+def _register_atexit_once() -> None:
+    global _atexit_registered
+    if _atexit_registered:
+        return
+    atexit.register(_drain_pending)
+    _atexit_registered = True
+
+
+def _drain_pending() -> None:
+    """Wait up to ``_ATEXIT_BUDGET_SECONDS`` total for in-flight sends to finish.
+
+    Without this, daemon-thread sends are killed mid-flight when the
+    interpreter exits, and POSTs are silently dropped before they reach the
+    network. The budget is shared across all pending threads.
+    """
+    with _pending_lock:
+        threads = [t for t in _pending_threads if t.is_alive()]
+        _pending_threads.clear()
+
+    if not threads:
+        return
+
+    deadline = threading.Event()
+    timer = threading.Timer(_ATEXIT_BUDGET_SECONDS, deadline.set)
+    timer.daemon = True
+    timer.start()
+    try:
+        for thread in threads:
+            if deadline.is_set():
+                break
+            # join blocks until the thread exits or its own timeout fires;
+            # urllib.request.urlopen already enforces a per-request timeout.
+            thread.join(timeout=_ATEXIT_BUDGET_SECONDS)
+    finally:
+        timer.cancel()
 
 
 def _is_debug(env: Mapping[str, str]) -> bool:
@@ -104,7 +150,9 @@ def send(
 ) -> None:
     """Fire-and-forget: POST on a daemon thread. Never raises, never blocks.
 
-    The thread is daemonised so process shutdown does not wait for it.
+    The thread is daemonised so process shutdown does not wait for it
+    indefinitely, but an ``atexit`` hook gives in-flight sends a bounded
+    budget to finish so a fast CLI exit doesn't kill the request mid-TLS.
     """
     try:
         thread = threading.Thread(
@@ -113,6 +161,9 @@ def send(
             name="docglow-telemetry",
             daemon=True,
         )
+        with _pending_lock:
+            _pending_threads.append(thread)
+            _register_atexit_once()
         thread.start()
     except Exception as exc:
         # Even thread-creation failures must not propagate.

--- a/src/docglow/telemetry/client.py
+++ b/src/docglow/telemetry/client.py
@@ -146,8 +146,13 @@ def _build_request(
     }
     bypass = env.get(ENV_VERCEL_BYPASS)
     if bypass:
+        # Send only the protection-bypass header, NOT x-vercel-set-bypass-cookie.
+        # The cookie variant returns a 307 + Set-Cookie(_vercel_jwt) that must
+        # be carried across the redirect; stdlib urllib has no cookie jar, so
+        # the loop never resolves. The header alone is enough for single
+        # fire-and-forget POSTs. (The cloud httpx.Client uses both headers
+        # because httpx persists cookies across redirects automatically.)
         headers["x-vercel-protection-bypass"] = bypass
-        headers["x-vercel-set-bypass-cookie"] = "true"
     return urllib.request.Request(
         url=endpoint,
         data=body,

--- a/src/docglow/telemetry/config.py
+++ b/src/docglow/telemetry/config.py
@@ -18,7 +18,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
 
-DEFAULT_ENDPOINT = "https://api.docglow.dev/v1/telemetry/events"
+DEFAULT_ENDPOINT = "https://api.docglow.com/v1/telemetry/events"
 
 ENV_OPT_IN = "DOCGLOW_TELEMETRY"
 ENV_OPT_OUT = "DOCGLOW_NO_TELEMETRY"

--- a/src/docglow/telemetry/config.py
+++ b/src/docglow/telemetry/config.py
@@ -14,6 +14,7 @@ This precedence is part of the user-facing privacy contract documented in
 from __future__ import annotations
 
 import os
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
 
@@ -54,7 +55,7 @@ def _parse_tristate(value: str | None) -> bool | None:
 
 def resolve_telemetry_config(
     raw: dict[str, Any] | None,
-    env: dict[str, str] | None = None,
+    env: Mapping[str, str] | None = None,
 ) -> TelemetryConfig:
     """Resolve final telemetry config from yml + env vars.
 
@@ -74,7 +75,7 @@ def resolve_telemetry_config(
     return TelemetryConfig(enabled=yml_enabled, endpoint=_resolve_endpoint(raw, environ))
 
 
-def _resolve_endpoint(raw: dict[str, Any] | None, env: dict[str, str]) -> str:
+def _resolve_endpoint(raw: dict[str, Any] | None, env: Mapping[str, str]) -> str:
     """Resolve the endpoint: env override > yml > default."""
     override = env.get(ENV_ENDPOINT_OVERRIDE)
     if override:

--- a/src/docglow/telemetry/config.py
+++ b/src/docglow/telemetry/config.py
@@ -1,0 +1,86 @@
+"""Telemetry configuration and env-var precedence resolution.
+
+Resolution order (highest precedence wins):
+
+    1. ``DOCGLOW_NO_TELEMETRY=1``  - force off, beats everything
+    2. ``DOCGLOW_TELEMETRY=1`` / ``DOCGLOW_TELEMETRY=0``
+    3. ``docglow.yml`` ``telemetry.enabled``
+    4. Default: ``False``
+
+This precedence is part of the user-facing privacy contract documented in
+``docs/telemetry.md`` -- changes here must be reflected there.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+DEFAULT_ENDPOINT = "https://api.docglow.dev/v1/telemetry/events"
+
+ENV_OPT_IN = "DOCGLOW_TELEMETRY"
+ENV_OPT_OUT = "DOCGLOW_NO_TELEMETRY"
+ENV_ENDPOINT_OVERRIDE = "DOCGLOW_TELEMETRY_ENDPOINT"
+
+_TRUTHY = {"1", "true", "yes", "on"}
+_FALSY = {"0", "false", "no", "off"}
+
+
+@dataclass(frozen=True)
+class TelemetryConfig:
+    """Resolved telemetry configuration.
+
+    ``enabled`` reflects the final answer after applying env-var precedence to
+    the yml flag. Components that need to know "should I send a payload?"
+    consult this single boolean and do not re-evaluate env vars.
+    """
+
+    enabled: bool = False
+    endpoint: str = DEFAULT_ENDPOINT
+
+
+def _parse_tristate(value: str | None) -> bool | None:
+    """Return True/False for an env var, or None when unset/unrecognised."""
+    if value is None:
+        return None
+    normalized = value.strip().lower()
+    if normalized in _TRUTHY:
+        return True
+    if normalized in _FALSY:
+        return False
+    return None
+
+
+def resolve_telemetry_config(
+    raw: dict[str, Any] | None,
+    env: dict[str, str] | None = None,
+) -> TelemetryConfig:
+    """Resolve final telemetry config from yml + env vars.
+
+    ``raw`` is the ``telemetry`` section of ``docglow.yml`` (or ``None``).
+    ``env`` defaults to ``os.environ``; injectable for tests.
+    """
+    environ = env if env is not None else os.environ
+
+    if _parse_tristate(environ.get(ENV_OPT_OUT)) is True:
+        return TelemetryConfig(enabled=False, endpoint=_resolve_endpoint(raw, environ))
+
+    env_opt_in = _parse_tristate(environ.get(ENV_OPT_IN))
+    if env_opt_in is not None:
+        return TelemetryConfig(enabled=env_opt_in, endpoint=_resolve_endpoint(raw, environ))
+
+    yml_enabled = bool(raw.get("enabled", False)) if isinstance(raw, dict) else False
+    return TelemetryConfig(enabled=yml_enabled, endpoint=_resolve_endpoint(raw, environ))
+
+
+def _resolve_endpoint(raw: dict[str, Any] | None, env: dict[str, str]) -> str:
+    """Resolve the endpoint: env override > yml > default."""
+    override = env.get(ENV_ENDPOINT_OVERRIDE)
+    if override:
+        return override
+    if isinstance(raw, dict):
+        endpoint = raw.get("endpoint")
+        if isinstance(endpoint, str) and endpoint:
+            return endpoint
+    return DEFAULT_ENDPOINT

--- a/src/docglow/telemetry/dispatcher.py
+++ b/src/docglow/telemetry/dispatcher.py
@@ -20,8 +20,9 @@ from __future__ import annotations
 import logging
 import os
 import time
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator, Mapping
 from contextlib import contextmanager
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from docglow.telemetry import client, state
@@ -46,7 +47,7 @@ logger = logging.getLogger(__name__)
 def is_active(
     config: TelemetryConfig,
     consent: state.ConsentValue,
-    env: dict[str, str] | None = None,
+    env: Mapping[str, str] | None = None,
 ) -> bool:
     """Return True iff telemetry should fire for this run."""
     environ = env if env is not None else os.environ
@@ -90,7 +91,7 @@ def project_shape_from_manifest(manifest: Manifest | None) -> ProjectShape:
         return ProjectShape()
 
 
-def project_shape_from_manifest_path(target_dir):
+def project_shape_from_manifest_path(target_dir: str | Path) -> ProjectShape:
     """Lightweight manifest.json reader for telemetry use.
 
     Reads only the fields we need (node resource_types, source/macro counts,
@@ -102,7 +103,6 @@ def project_shape_from_manifest_path(target_dir):
     calling command.
     """
     import json
-    from pathlib import Path
 
     try:
         path = Path(target_dir) / "manifest.json"
@@ -147,7 +147,7 @@ def record_command(
     project_shape: ProjectShape | None = None,
     features_used: tuple[str, ...] = (),
     consent: state.ConsentValue | None = None,
-    state_path=None,
+    state_path: Path | None = None,
     send: bool = True,
 ) -> dict[str, object] | None:
     """Build and dispatch a telemetry event if telemetry is active.
@@ -192,7 +192,7 @@ def record(
     config: TelemetryConfig,
     *,
     command: CommandName,
-    manifest_provider=None,
+    manifest_provider: Callable[[], Manifest | None] | None = None,
     features_used: tuple[str, ...] = (),
 ) -> Iterator[None]:
     """Context manager that times a command and records success/error on exit.

--- a/src/docglow/telemetry/dispatcher.py
+++ b/src/docglow/telemetry/dispatcher.py
@@ -1,0 +1,227 @@
+"""Telemetry dispatcher: the single integration point used by CLI commands.
+
+Owns the gate logic ("should we send?"), payload assembly, and dispatch. CLI
+commands call ``record_command`` (or use the ``record`` context manager) and
+remain ignorant of every other module in this package.
+
+Gate logic, in order:
+
+    1. ``DOCGLOW_NO_TELEMETRY=1`` -- force off (re-checked here defensively
+       even though it is also folded into ``TelemetryConfig.enabled``).
+    2. ``config.enabled`` -- env opt-in or yml flag says yes.
+    3. ``consent == 'yes'`` -- the user accepted the first-run prompt.
+
+Anything that fails any of these returns silently. Failures inside this
+module never raise into the caller.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+from docglow.telemetry import client, state
+from docglow.telemetry.config import (
+    ENV_OPT_OUT,
+    TelemetryConfig,
+    _parse_tristate,
+)
+from docglow.telemetry.payload import (
+    CommandName,
+    ProjectShape,
+    ResultName,
+    build_event,
+)
+
+if TYPE_CHECKING:
+    from docglow.artifacts.manifest import Manifest
+
+logger = logging.getLogger(__name__)
+
+
+def is_active(
+    config: TelemetryConfig,
+    consent: state.ConsentValue,
+    env: dict[str, str] | None = None,
+) -> bool:
+    """Return True iff telemetry should fire for this run."""
+    environ = env if env is not None else os.environ
+    if _parse_tristate(environ.get(ENV_OPT_OUT)) is True:
+        return False
+    if config.enabled:
+        return True
+    return consent == "yes"
+
+
+def project_shape_from_manifest(manifest: Manifest | None) -> ProjectShape:
+    """Build an anonymous ProjectShape from an in-memory dbt Manifest.
+
+    Returns a zero-shape if the manifest is None or any field access fails.
+    """
+    if manifest is None:
+        return ProjectShape()
+    try:
+        nodes = manifest.nodes.values() if hasattr(manifest, "nodes") else []
+        models = sum(1 for n in nodes if getattr(n, "resource_type", "") == "model")
+        seeds = sum(1 for n in nodes if getattr(n, "resource_type", "") == "seed")
+        tests = sum(1 for n in nodes if getattr(n, "resource_type", "") == "test")
+        sources = len(manifest.sources) if hasattr(manifest, "sources") and manifest.sources else 0
+        macros = len(manifest.macros) if hasattr(manifest, "macros") and manifest.macros else 0
+        adapter_type: str | None = None
+        metadata = getattr(manifest, "metadata", None)
+        if metadata is not None:
+            raw = getattr(metadata, "adapter_type", None)
+            if isinstance(raw, str) and raw:
+                adapter_type = raw.lower()
+        return ProjectShape(
+            models=models,
+            sources=sources,
+            seeds=seeds,
+            tests=tests,
+            macros=macros,
+            adapter_type=adapter_type,
+        )
+    except Exception as exc:
+        logger.debug("telemetry: failed to derive ProjectShape from manifest: %s", exc)
+        return ProjectShape()
+
+
+def project_shape_from_manifest_path(target_dir):
+    """Lightweight manifest.json reader for telemetry use.
+
+    Reads only the fields we need (node resource_types, source/macro counts,
+    adapter_type) without going through pydantic validation. Used by CLI
+    commands that don't otherwise hold a Manifest object so they can record
+    a meaningful payload without paying for full artifact loading.
+
+    Returns ProjectShape() on any failure -- this must never break the
+    calling command.
+    """
+    import json
+    from pathlib import Path
+
+    try:
+        path = Path(target_dir) / "manifest.json"
+        with path.open(encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception as exc:
+        logger.debug("telemetry: manifest.json peek failed: %s", exc)
+        return ProjectShape()
+
+    try:
+        nodes = data.get("nodes", {}) or {}
+        models = sum(1 for n in nodes.values() if n.get("resource_type") == "model")
+        seeds = sum(1 for n in nodes.values() if n.get("resource_type") == "seed")
+        tests = sum(1 for n in nodes.values() if n.get("resource_type") == "test")
+        sources = len(data.get("sources", {}) or {})
+        macros = len(data.get("macros", {}) or {})
+        adapter_type = None
+        metadata = data.get("metadata") or {}
+        raw = metadata.get("adapter_type")
+        if isinstance(raw, str) and raw:
+            adapter_type = raw.lower()
+        return ProjectShape(
+            models=models,
+            sources=sources,
+            seeds=seeds,
+            tests=tests,
+            macros=macros,
+            adapter_type=adapter_type,
+        )
+    except Exception as exc:
+        logger.debug("telemetry: manifest.json parse failed: %s", exc)
+        return ProjectShape()
+
+
+def record_command(
+    config: TelemetryConfig,
+    *,
+    command: CommandName,
+    result: ResultName,
+    duration_ms: int,
+    manifest: Manifest | None = None,
+    project_shape: ProjectShape | None = None,
+    features_used: tuple[str, ...] = (),
+    consent: state.ConsentValue | None = None,
+    state_path=None,
+    send: bool = True,
+) -> dict[str, object] | None:
+    """Build and dispatch a telemetry event if telemetry is active.
+
+    Pass ``project_shape`` directly when the caller already has it, or
+    ``manifest`` (an in-memory Manifest) for the dispatcher to derive shape.
+    If both are None the payload reports a zero shape -- still valid for
+    commands like ``serve`` that don't necessarily have a manifest at hand.
+
+    Returns the payload that was (or would have been) sent, or None when
+    telemetry is inactive. Useful for tests; production callers ignore the
+    return value.
+
+    Never raises.
+    """
+    try:
+        resolved_consent = consent if consent is not None else state.get_consent(state_path)
+        if not is_active(config, resolved_consent):
+            return None
+
+        instance_id = state.get_instance_id(state_path)
+        if project_shape is None:
+            project_shape = project_shape_from_manifest(manifest)
+        payload = build_event(
+            instance_id=instance_id,
+            command=command,
+            result=result,
+            duration_ms=duration_ms,
+            project_shape=project_shape,
+            features_used=features_used,
+        )
+        if send:
+            client.send(payload, config.endpoint)
+        return payload
+    except Exception as exc:
+        logger.debug("telemetry: record_command failed: %s", exc)
+        return None
+
+
+@contextmanager
+def record(
+    config: TelemetryConfig,
+    *,
+    command: CommandName,
+    manifest_provider=None,
+    features_used: tuple[str, ...] = (),
+) -> Iterator[None]:
+    """Context manager that times a command and records success/error on exit.
+
+    ``manifest_provider`` is an optional zero-arg callable returning the
+    Manifest (or None). Called inside the ``finally`` block so it picks up
+    a manifest that was loaded mid-command, even on error.
+    """
+    started = time.monotonic()
+    success = False
+    try:
+        yield
+        success = True
+    finally:
+        try:
+            duration_ms = int((time.monotonic() - started) * 1000)
+            manifest = None
+            if manifest_provider is not None:
+                try:
+                    manifest = manifest_provider()
+                except Exception:
+                    manifest = None
+            record_command(
+                config,
+                command=command,
+                result="success" if success else "error",
+                duration_ms=duration_ms,
+                manifest=manifest,
+                features_used=features_used,
+            )
+        except Exception as exc:
+            logger.debug("telemetry: record context exit failed: %s", exc)

--- a/src/docglow/telemetry/payload.py
+++ b/src/docglow/telemetry/payload.py
@@ -1,0 +1,91 @@
+"""Build telemetry event payloads.
+
+Pure functions only -- no I/O, no global state. Callers gather the inputs
+(``ProjectShape`` from a manifest, command + result + duration_ms from the
+dispatcher) and pass them in. The builder returns a v1 payload dict matching
+the schema documented in ``docs/telemetry.md``.
+
+The module uses an explicit allow-list for fields. New fields require an
+intentional code change here, never an accidental kwargs passthrough -- this
+is the load-bearing safeguard against leaking model names, paths, or other
+identifying data through a manifest field nobody noticed.
+"""
+
+from __future__ import annotations
+
+import platform as _platform
+import sys
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import docglow as _docglow
+
+SCHEMA_VERSION = 1
+
+CommandName = Literal["generate", "health", "serve"]
+ResultName = Literal["success", "error"]
+
+
+@dataclass(frozen=True)
+class ProjectShape:
+    """Anonymized shape of a dbt project, derived from the manifest.
+
+    Only counts and the adapter type. No names, no paths, no SQL, no columns.
+    """
+
+    models: int = 0
+    sources: int = 0
+    seeds: int = 0
+    tests: int = 0
+    macros: int = 0
+    adapter_type: str | None = None
+
+
+def _platform_short() -> str:
+    """Return a coarse platform name: 'linux', 'darwin', 'windows', or 'other'."""
+    system = _platform.system().lower()
+    if system in ("linux", "darwin", "windows"):
+        return system
+    return "other"
+
+
+def _python_version_short() -> str:
+    """Return ``major.minor.micro`` -- no implementation/build suffixes."""
+    return f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+
+
+def build_event(
+    *,
+    instance_id: str,
+    command: CommandName,
+    result: ResultName,
+    duration_ms: int,
+    project_shape: ProjectShape | None,
+    features_used: tuple[str, ...] = (),
+) -> dict[str, Any]:
+    """Build a v1 telemetry event payload.
+
+    Returns a JSON-serialisable dict. The shape is fixed; new fields require
+    a deliberate edit here and a corresponding update to ``docs/telemetry.md``
+    and the snapshot test.
+    """
+    shape = project_shape or ProjectShape()
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "instance_id": instance_id,
+        "command": command,
+        "result": result,
+        "duration_ms": int(duration_ms),
+        "docglow_version": _docglow.__version__,
+        "python_version": _python_version_short(),
+        "platform": _platform_short(),
+        "adapter_type": shape.adapter_type,
+        "project_shape": {
+            "models": shape.models,
+            "sources": shape.sources,
+            "seeds": shape.seeds,
+            "tests": shape.tests,
+            "macros": shape.macros,
+        },
+        "features_used": list(features_used),
+    }

--- a/src/docglow/telemetry/state.py
+++ b/src/docglow/telemetry/state.py
@@ -1,0 +1,138 @@
+"""Persistent telemetry state: anonymous instance ID and consent.
+
+State file lives at ``click.get_app_dir("docglow")/telemetry.json`` and stores
+a stable UUID4 plus a tri-state consent flag. All read/write paths swallow
+exceptions -- a corrupt or unwritable state file must never break a CLI
+command.
+
+State payload v1::
+
+    {
+        "version": 1,
+        "instance_id": "<uuid4>",
+        "consent": "yes" | "no" | "unset",
+        "consent_recorded_at": "<iso8601>"  # only set when consent is yes/no
+    }
+
+Mirrors the discipline of :mod:`docglow.cloud_hint`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Literal
+
+import click
+
+STATE_FILENAME = "telemetry.json"
+STATE_VERSION = 1
+
+ConsentValue = Literal["yes", "no", "unset"]
+_VALID_CONSENT: tuple[ConsentValue, ...] = ("yes", "no", "unset")
+
+
+def _state_path() -> Path:
+    """Return the path to the telemetry state file. Factored for test monkeypatching."""
+    return Path(click.get_app_dir("docglow")) / STATE_FILENAME
+
+
+def _read_payload(path: Path) -> dict[str, object]:
+    """Return the validated state payload, or an empty dict on missing/corrupt input."""
+    try:
+        raw = path.read_text(encoding="utf-8")
+        payload = json.loads(raw)
+        if not isinstance(payload, dict):
+            return {}
+        if payload.get("version") != STATE_VERSION:
+            return {}
+        return payload
+    except Exception:
+        return {}
+
+
+def _write_payload(path: Path, payload: dict[str, object]) -> None:
+    """Atomically persist a state payload. Swallows all exceptions."""
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_text(json.dumps(payload), encoding="utf-8")
+        os.replace(tmp, path)
+    except Exception:
+        # Best-effort: a failed write means we may regenerate the instance_id
+        # next call or fail to record consent. Both are acceptable degradations.
+        pass
+
+
+def _is_valid_uuid(value: object) -> bool:
+    if not isinstance(value, str):
+        return False
+    try:
+        uuid.UUID(value)
+    except (ValueError, AttributeError, TypeError):
+        return False
+    return True
+
+
+def _normalize_consent(value: object) -> ConsentValue:
+    if value in _VALID_CONSENT:
+        return value  # type: ignore[return-value]
+    return "unset"
+
+
+def _build_payload(
+    instance_id: str, consent: ConsentValue, recorded_at: str | None
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "version": STATE_VERSION,
+        "instance_id": instance_id,
+        "consent": consent,
+    }
+    if recorded_at is not None:
+        payload["consent_recorded_at"] = recorded_at
+    return payload
+
+
+def get_instance_id(path: Path | None = None) -> str:
+    """Return the persisted UUID4, generating and persisting one if absent.
+
+    Always returns a valid UUID4 string. If persistence fails, returns a fresh
+    UUID this call (subsequent calls may regenerate -- acceptable since failed
+    writes already mean we have no durable state).
+    """
+    target = path or _state_path()
+    payload = _read_payload(target)
+    existing = payload.get("instance_id")
+    if _is_valid_uuid(existing):
+        return existing  # type: ignore[return-value]
+
+    fresh = str(uuid.uuid4())
+    consent = _normalize_consent(payload.get("consent"))
+    recorded_at = payload.get("consent_recorded_at")
+    if not isinstance(recorded_at, str):
+        recorded_at = None
+    _write_payload(target, _build_payload(fresh, consent, recorded_at))
+    return fresh
+
+
+def get_consent(path: Path | None = None) -> ConsentValue:
+    """Return the recorded consent value, or 'unset' if none/invalid."""
+    target = path or _state_path()
+    payload = _read_payload(target)
+    return _normalize_consent(payload.get("consent"))
+
+
+def set_consent(consent: ConsentValue, path: Path | None = None) -> None:
+    """Record consent. Preserves instance_id if present, generates one if not."""
+    if consent not in _VALID_CONSENT:
+        raise ValueError(f"consent must be one of {_VALID_CONSENT}, got {consent!r}")
+    target = path or _state_path()
+    payload = _read_payload(target)
+    instance_id = payload.get("instance_id")
+    if not _is_valid_uuid(instance_id):
+        instance_id = str(uuid.uuid4())
+    recorded_at = datetime.now(timezone.utc).isoformat() if consent != "unset" else None
+    _write_payload(target, _build_payload(instance_id, consent, recorded_at))  # type: ignore[arg-type]

--- a/src/docglow/telemetry/state.py
+++ b/src/docglow/telemetry/state.py
@@ -78,8 +78,10 @@ def _is_valid_uuid(value: object) -> bool:
 
 
 def _normalize_consent(value: object) -> ConsentValue:
-    if value in _VALID_CONSENT:
-        return value  # type: ignore[return-value]
+    if value == "yes":
+        return "yes"
+    if value == "no":
+        return "no"
     return "unset"
 
 

--- a/tests/telemetry/test_client.py
+++ b/tests/telemetry/test_client.py
@@ -235,44 +235,97 @@ def test_send_sync_omits_vercel_bypass_headers_when_env_unset() -> None:
     assert "x-vercel-set-bypass-cookie" not in captured
 
 
-def test_send_sync_emits_info_log_when_debug_enabled(
-    caplog: pytest.LogCaptureFixture,
+def test_send_sync_emits_stderr_diag_when_debug_enabled(
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     with _StubServer() as stub:
-        with caplog.at_level("INFO", logger="docglow.telemetry.client"):
-            client.send_sync(
-                {"x": 1},
-                stub.url,
-                env={"DOCGLOW_TELEMETRY_DEBUG": "1"},
-            )
-
-    info_messages = [r.getMessage() for r in caplog.records if r.levelname == "INFO"]
-    assert any("telemetry: POST" in m and "204" in m for m in info_messages)
-
-
-def test_send_sync_silent_when_debug_disabled(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    with _StubServer() as stub:
-        with caplog.at_level("INFO", logger="docglow.telemetry.client"):
-            client.send_sync({"x": 1}, stub.url, env={})
-
-    info_messages = [r.getMessage() for r in caplog.records if r.levelname == "INFO"]
-    assert info_messages == []
-
-
-def test_send_sync_debug_log_on_failure(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    with caplog.at_level("INFO", logger="docglow.telemetry.client"):
         client.send_sync(
             {"x": 1},
-            "http://127.0.0.1:1/",
+            stub.url,
             env={"DOCGLOW_TELEMETRY_DEBUG": "1"},
         )
 
-    info_messages = [r.getMessage() for r in caplog.records if r.levelname == "INFO"]
-    assert any("failed" in m for m in info_messages)
+    err = capsys.readouterr().err
+    assert "telemetry: POST" in err
+    assert "204" in err
+
+
+def test_send_sync_silent_when_debug_disabled(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with _StubServer() as stub:
+        client.send_sync({"x": 1}, stub.url, env={})
+
+    err = capsys.readouterr().err
+    assert "telemetry:" not in err
+
+
+def test_send_sync_debug_diag_on_failure(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    client.send_sync(
+        {"x": 1},
+        "http://127.0.0.1:1/",
+        env={"DOCGLOW_TELEMETRY_DEBUG": "1"},
+    )
+
+    err = capsys.readouterr().err
+    assert "failed" in err
+
+
+def test_send_sync_follows_307_redirect_preserving_post_and_body() -> None:
+    """Vercel issues 307s for host/path canonicalization; stdlib urllib raises
+    on POST + 307 by default. The custom redirect handler must follow with
+    the original method and body.
+    """
+    received: list[tuple[str, dict[str, Any]]] = []
+
+    class RedirectingHandler(BaseHTTPRequestHandler):
+        target_url: str = ""
+
+        def log_message(self, *_args: Any) -> None:
+            return
+
+        def do_POST(self) -> None:  # noqa: N802
+            length = int(self.headers.get("Content-Length", "0"))
+            body = self.rfile.read(length)
+            try:
+                payload = json.loads(body.decode("utf-8"))
+            except Exception:
+                payload = {}
+            if self.path == "/v1/telemetry/events":
+                received.append(("first", payload))
+                self.send_response(307)
+                self.send_header("Location", self.target_url + "/final")
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+            elif self.path == "/final":
+                received.append(("final", payload))
+                self.send_response(204)
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+            else:
+                self.send_response(404)
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+
+    server = HTTPServer(("127.0.0.1", 0), RedirectingHandler)
+    base = f"http://127.0.0.1:{server.server_address[1]}"
+    RedirectingHandler.target_url = base
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        ok = client.send_sync({"hello": "world"}, base + "/v1/telemetry/events")
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert ok is True
+    # Both legs of the redirect should have received the body.
+    assert received == [
+        ("first", {"hello": "world"}),
+        ("final", {"hello": "world"}),
+    ]
 
 
 def test_drain_pending_completes_in_flight_sends() -> None:

--- a/tests/telemetry/test_client.py
+++ b/tests/telemetry/test_client.py
@@ -273,3 +273,28 @@ def test_send_sync_debug_log_on_failure(
 
     info_messages = [r.getMessage() for r in caplog.records if r.levelname == "INFO"]
     assert any("failed" in m for m in info_messages)
+
+
+def test_drain_pending_completes_in_flight_sends() -> None:
+    """An in-flight send launched via send() must complete when _drain_pending runs.
+
+    Regression: without atexit drain, the daemon thread is killed at process
+    exit and the POST never reaches the server. We simulate process exit by
+    invoking _drain_pending() directly after send().
+    """
+
+    def slow_handler(_payload: dict[str, Any]) -> tuple[int, bytes]:
+        # Long enough to ensure the request would not finish before
+        # send() returns, but well within the drain budget.
+        time.sleep(0.3)
+        return (204, b"")
+
+    with _StubServer(on_request=slow_handler) as stub:
+        # Reset module state so this test is hermetic.
+        with client._pending_lock:
+            client._pending_threads.clear()
+        client.send({"x": 1}, stub.url, timeout=2.0)
+        # Simulate process exit.
+        client._drain_pending()
+
+    assert stub.received == [{"x": 1}]

--- a/tests/telemetry/test_client.py
+++ b/tests/telemetry/test_client.py
@@ -1,0 +1,174 @@
+"""Tests for docglow.telemetry.client.
+
+Uses Python's stdlib http.server rather than pytest-httpserver to avoid
+adding a test dep just for this. The server is in a thread so we can
+control its behaviour per-test.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from collections.abc import Callable
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+
+import pytest
+
+from docglow.telemetry import client
+
+
+def _make_handler(
+    on_request: Callable[[dict[str, Any]], tuple[int, bytes]],
+) -> type[BaseHTTPRequestHandler]:
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *_args: Any) -> None:  # silence
+            return
+
+        def do_POST(self) -> None:  # noqa: N802
+            length = int(self.headers.get("Content-Length", "0"))
+            body = self.rfile.read(length)
+            try:
+                payload = json.loads(body.decode("utf-8"))
+            except Exception:
+                payload = {}
+            status, response_body = on_request(payload)
+            self.send_response(status)
+            self.send_header("Content-Length", str(len(response_body)))
+            self.end_headers()
+            self.wfile.write(response_body)
+
+    return Handler
+
+
+class _StubServer:
+    def __init__(
+        self,
+        on_request: Callable[[dict[str, Any]], tuple[int, bytes]] | None = None,
+    ) -> None:
+        self.received: list[dict[str, Any]] = []
+        self._handler_factory = on_request or self._default_handler
+        handler_cls = _make_handler(self._record_and_dispatch)
+        self.server = HTTPServer(("127.0.0.1", 0), handler_cls)
+        self.url = f"http://127.0.0.1:{self.server.server_address[1]}/"
+        self._thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+
+    def _default_handler(self, _payload: dict[str, Any]) -> tuple[int, bytes]:
+        return (204, b"")
+
+    def _record_and_dispatch(self, payload: dict[str, Any]) -> tuple[int, bytes]:
+        self.received.append(payload)
+        return self._handler_factory(payload)
+
+    def __enter__(self) -> _StubServer:
+        self._thread.start()
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+
+
+def test_send_sync_204_returns_true() -> None:
+    with _StubServer() as stub:
+        ok = client.send_sync({"hello": "world"}, stub.url)
+    assert ok is True
+    assert stub.received == [{"hello": "world"}]
+
+
+def test_send_sync_500_returns_false_does_not_raise() -> None:
+    with _StubServer(on_request=lambda _p: (500, b"server error")) as stub:
+        ok = client.send_sync({"x": 1}, stub.url)
+    assert ok is False
+    # Server still received the request
+    assert stub.received == [{"x": 1}]
+
+
+def test_send_sync_connection_refused_does_not_raise() -> None:
+    # 127.0.0.1:1 is reliably refused
+    ok = client.send_sync({"x": 1}, "http://127.0.0.1:1/")
+    assert ok is False
+
+
+def test_send_sync_timeout_does_not_raise() -> None:
+    def slow_handler(_payload: dict[str, Any]) -> tuple[int, bytes]:
+        time.sleep(0.5)
+        return (204, b"")
+
+    with _StubServer(on_request=slow_handler) as stub:
+        ok = client.send_sync({"x": 1}, stub.url, timeout=0.05)
+    assert ok is False
+
+
+def test_send_sync_invalid_url_does_not_raise() -> None:
+    ok = client.send_sync({"x": 1}, "not-a-url")
+    assert ok is False
+
+
+def test_send_sync_includes_user_agent_and_content_type() -> None:
+    captured: dict[str, str] = {}
+
+    class CapturingHandler(BaseHTTPRequestHandler):
+        def log_message(self, *_args: Any) -> None:
+            return
+
+        def do_POST(self) -> None:  # noqa: N802
+            captured["user_agent"] = self.headers.get("User-Agent", "")
+            captured["content_type"] = self.headers.get("Content-Type", "")
+            length = int(self.headers.get("Content-Length", "0"))
+            self.rfile.read(length)
+            self.send_response(204)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+    server = HTTPServer(("127.0.0.1", 0), CapturingHandler)
+    url = f"http://127.0.0.1:{server.server_address[1]}/"
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        client.send_sync({"x": 1}, url)
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert captured["content_type"] == "application/json"
+    assert captured["user_agent"].startswith("docglow-cli-telemetry/")
+
+
+def test_send_async_returns_immediately_even_with_slow_server() -> None:
+    def slow_handler(_payload: dict[str, Any]) -> tuple[int, bytes]:
+        time.sleep(1.0)
+        return (204, b"")
+
+    with _StubServer(on_request=slow_handler) as stub:
+        start = time.monotonic()
+        client.send({"x": 1}, stub.url, timeout=2.0)
+        elapsed = time.monotonic() - start
+
+    # Caller should not block on the slow server. 200ms is generous; in
+    # practice this is < 10ms.
+    assert elapsed < 0.2, f"send() blocked for {elapsed:.3f}s"
+
+
+def test_send_async_does_not_raise_on_bad_endpoint() -> None:
+    # Should not raise even when the endpoint is unreachable
+    client.send({"x": 1}, "http://127.0.0.1:1/")
+
+
+def test_send_async_eventually_delivers(tmp_path: Any) -> None:
+    with _StubServer() as stub:
+        client.send({"x": 1}, stub.url, timeout=2.0)
+        # Allow a moment for the daemon thread to complete the request
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline and not stub.received:
+            time.sleep(0.02)
+
+    assert stub.received == [{"x": 1}]
+
+
+@pytest.mark.parametrize("status", [400, 404, 413, 429, 500, 503])
+def test_send_sync_non_2xx_returns_false(status: int) -> None:
+    with _StubServer(on_request=lambda _p: (status, b"")) as stub:
+        ok = client.send_sync({"x": 1}, stub.url)
+    assert ok is False

--- a/tests/telemetry/test_client.py
+++ b/tests/telemetry/test_client.py
@@ -209,7 +209,7 @@ def _capture_headers() -> tuple[str, dict[str, str], Callable[[], None]]:
     return url, captured, shutdown
 
 
-def test_send_sync_attaches_vercel_bypass_headers_when_env_set() -> None:
+def test_send_sync_attaches_vercel_bypass_header_when_env_set() -> None:
     url, captured, shutdown = _capture_headers()
     try:
         client.send_sync(
@@ -221,7 +221,11 @@ def test_send_sync_attaches_vercel_bypass_headers_when_env_set() -> None:
         shutdown()
 
     assert captured.get("x-vercel-protection-bypass") == "secret-token"
-    assert captured.get("x-vercel-set-bypass-cookie") == "true"
+    # Must NOT send x-vercel-set-bypass-cookie: stdlib urllib has no cookie
+    # jar, and Vercel's cookie-bypass flow returns a 307 + Set-Cookie that
+    # the client is expected to carry across the redirect. Sending the
+    # header without cookie support produces an unbreakable redirect loop.
+    assert "x-vercel-set-bypass-cookie" not in captured
 
 
 def test_send_sync_omits_vercel_bypass_headers_when_env_unset() -> None:

--- a/tests/telemetry/test_client.py
+++ b/tests/telemetry/test_client.py
@@ -172,3 +172,104 @@ def test_send_sync_non_2xx_returns_false(status: int) -> None:
     with _StubServer(on_request=lambda _p: (status, b"")) as stub:
         ok = client.send_sync({"x": 1}, stub.url)
     assert ok is False
+
+
+def _capture_headers() -> tuple[str, dict[str, str], Callable[[], None]]:
+    captured: dict[str, str] = {}
+
+    class CapturingHandler(BaseHTTPRequestHandler):
+        def log_message(self, *_args: Any) -> None:
+            return
+
+        def do_POST(self) -> None:  # noqa: N802
+            for name in (
+                "x-vercel-protection-bypass",
+                "x-vercel-set-bypass-cookie",
+                "User-Agent",
+                "Content-Type",
+            ):
+                value = self.headers.get(name)
+                if value is not None:
+                    captured[name] = value
+            length = int(self.headers.get("Content-Length", "0"))
+            self.rfile.read(length)
+            self.send_response(204)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+    server = HTTPServer(("127.0.0.1", 0), CapturingHandler)
+    url = f"http://127.0.0.1:{server.server_address[1]}/"
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    def shutdown() -> None:
+        server.shutdown()
+        server.server_close()
+
+    return url, captured, shutdown
+
+
+def test_send_sync_attaches_vercel_bypass_headers_when_env_set() -> None:
+    url, captured, shutdown = _capture_headers()
+    try:
+        client.send_sync(
+            {"x": 1},
+            url,
+            env={"DOCGLOW_VERCEL_BYPASS": "secret-token"},
+        )
+    finally:
+        shutdown()
+
+    assert captured.get("x-vercel-protection-bypass") == "secret-token"
+    assert captured.get("x-vercel-set-bypass-cookie") == "true"
+
+
+def test_send_sync_omits_vercel_bypass_headers_when_env_unset() -> None:
+    url, captured, shutdown = _capture_headers()
+    try:
+        client.send_sync({"x": 1}, url, env={})
+    finally:
+        shutdown()
+
+    assert "x-vercel-protection-bypass" not in captured
+    assert "x-vercel-set-bypass-cookie" not in captured
+
+
+def test_send_sync_emits_info_log_when_debug_enabled(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with _StubServer() as stub:
+        with caplog.at_level("INFO", logger="docglow.telemetry.client"):
+            client.send_sync(
+                {"x": 1},
+                stub.url,
+                env={"DOCGLOW_TELEMETRY_DEBUG": "1"},
+            )
+
+    info_messages = [r.getMessage() for r in caplog.records if r.levelname == "INFO"]
+    assert any("telemetry: POST" in m and "204" in m for m in info_messages)
+
+
+def test_send_sync_silent_when_debug_disabled(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with _StubServer() as stub:
+        with caplog.at_level("INFO", logger="docglow.telemetry.client"):
+            client.send_sync({"x": 1}, stub.url, env={})
+
+    info_messages = [r.getMessage() for r in caplog.records if r.levelname == "INFO"]
+    assert info_messages == []
+
+
+def test_send_sync_debug_log_on_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level("INFO", logger="docglow.telemetry.client"):
+        client.send_sync(
+            {"x": 1},
+            "http://127.0.0.1:1/",
+            env={"DOCGLOW_TELEMETRY_DEBUG": "1"},
+        )
+
+    info_messages = [r.getMessage() for r in caplog.records if r.levelname == "INFO"]
+    assert any("failed" in m for m in info_messages)

--- a/tests/telemetry/test_config.py
+++ b/tests/telemetry/test_config.py
@@ -1,0 +1,97 @@
+"""Tests for docglow.telemetry.config."""
+
+from __future__ import annotations
+
+import pytest
+
+from docglow.telemetry.config import (
+    DEFAULT_ENDPOINT,
+    ENV_ENDPOINT_OVERRIDE,
+    ENV_OPT_IN,
+    ENV_OPT_OUT,
+    TelemetryConfig,
+    resolve_telemetry_config,
+)
+
+
+def test_default_disabled_with_no_yml_or_env() -> None:
+    config = resolve_telemetry_config(None, env={})
+    assert config == TelemetryConfig(enabled=False, endpoint=DEFAULT_ENDPOINT)
+
+
+def test_yml_enabled_true_no_env() -> None:
+    config = resolve_telemetry_config({"enabled": True}, env={})
+    assert config.enabled is True
+
+
+def test_env_opt_in_overrides_yml_disabled() -> None:
+    config = resolve_telemetry_config({"enabled": False}, env={ENV_OPT_IN: "1"})
+    assert config.enabled is True
+
+
+def test_env_opt_in_zero_overrides_yml_enabled() -> None:
+    config = resolve_telemetry_config({"enabled": True}, env={ENV_OPT_IN: "0"})
+    assert config.enabled is False
+
+
+def test_no_telemetry_beats_opt_in() -> None:
+    config = resolve_telemetry_config({"enabled": True}, env={ENV_OPT_IN: "1", ENV_OPT_OUT: "1"})
+    assert config.enabled is False
+
+
+def test_no_telemetry_beats_yml_enabled() -> None:
+    config = resolve_telemetry_config({"enabled": True}, env={ENV_OPT_OUT: "1"})
+    assert config.enabled is False
+
+
+@pytest.mark.parametrize("truthy", ["1", "true", "TRUE", "yes", "on", "  YES  "])
+def test_truthy_env_values_recognised(truthy: str) -> None:
+    config = resolve_telemetry_config(None, env={ENV_OPT_IN: truthy})
+    assert config.enabled is True
+
+
+@pytest.mark.parametrize("falsy", ["0", "false", "no", "off"])
+def test_falsy_env_values_recognised(falsy: str) -> None:
+    config = resolve_telemetry_config({"enabled": True}, env={ENV_OPT_IN: falsy})
+    assert config.enabled is False
+
+
+def test_unknown_env_value_falls_through_to_yml() -> None:
+    config = resolve_telemetry_config({"enabled": True}, env={ENV_OPT_IN: "maybe"})
+    assert config.enabled is True
+
+
+def test_endpoint_default() -> None:
+    config = resolve_telemetry_config(None, env={})
+    assert config.endpoint == DEFAULT_ENDPOINT
+
+
+def test_endpoint_yml_override() -> None:
+    config = resolve_telemetry_config({"endpoint": "https://example.test/e"}, env={})
+    assert config.endpoint == "https://example.test/e"
+
+
+def test_endpoint_env_overrides_yml() -> None:
+    config = resolve_telemetry_config(
+        {"endpoint": "https://yml.test/e"},
+        env={ENV_ENDPOINT_OVERRIDE: "https://env.test/e"},
+    )
+    assert config.endpoint == "https://env.test/e"
+
+
+def test_yml_missing_enabled_treated_as_disabled() -> None:
+    config = resolve_telemetry_config({}, env={})
+    assert config.enabled is False
+
+
+def test_yml_non_dict_treated_as_missing() -> None:
+    # A user who writes ``telemetry: true`` (rather than ``telemetry: {enabled: true}``)
+    # should get sane behaviour, not a crash.
+    config = resolve_telemetry_config("not-a-dict", env={ENV_OPT_IN: "1"})  # type: ignore[arg-type]
+    assert config.enabled is True
+
+
+def test_default_uses_real_environ_when_env_not_passed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ENV_OPT_IN, "1")
+    config = resolve_telemetry_config(None)
+    assert config.enabled is True

--- a/tests/telemetry/test_dispatcher.py
+++ b/tests/telemetry/test_dispatcher.py
@@ -1,0 +1,211 @@
+"""Tests for docglow.telemetry.dispatcher."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from docglow.telemetry import state
+from docglow.telemetry.config import (
+    ENV_OPT_OUT,
+    TelemetryConfig,
+)
+from docglow.telemetry.dispatcher import (
+    is_active,
+    project_shape_from_manifest_path,
+    record_command,
+)
+from docglow.telemetry.payload import ProjectShape
+
+
+def _enabled_config() -> TelemetryConfig:
+    return TelemetryConfig(enabled=True, endpoint="http://localhost:1/telemetry")
+
+
+def _disabled_config() -> TelemetryConfig:
+    return TelemetryConfig(enabled=False, endpoint="http://localhost:1/telemetry")
+
+
+# ---- is_active --------------------------------------------------------------
+
+
+def test_is_active_when_config_enabled_and_no_consent_required() -> None:
+    assert is_active(_enabled_config(), consent="unset", env={}) is True
+
+
+def test_is_active_when_consent_yes_even_if_config_disabled() -> None:
+    assert is_active(_disabled_config(), consent="yes", env={}) is True
+
+
+def test_is_active_false_when_disabled_and_consent_unset() -> None:
+    assert is_active(_disabled_config(), consent="unset", env={}) is False
+
+
+def test_is_active_false_when_consent_no() -> None:
+    assert is_active(_disabled_config(), consent="no", env={}) is False
+
+
+def test_no_telemetry_env_overrides_consent_yes() -> None:
+    assert is_active(_disabled_config(), consent="yes", env={ENV_OPT_OUT: "1"}) is False
+
+
+def test_no_telemetry_env_overrides_config_enabled() -> None:
+    # Config could still report enabled=True if it was constructed with
+    # injected env that didn't include opt-out; the dispatcher re-checks.
+    assert is_active(_enabled_config(), consent="yes", env={ENV_OPT_OUT: "1"}) is False
+
+
+# ---- record_command ---------------------------------------------------------
+
+
+def test_record_command_returns_none_when_inactive(tmp_path: Path) -> None:
+    state_path = tmp_path / "telemetry.json"
+    payload = record_command(
+        _disabled_config(),
+        command="generate",
+        result="success",
+        duration_ms=10,
+        consent="no",
+        state_path=state_path,
+        send=False,
+    )
+    assert payload is None
+
+
+def test_record_command_builds_payload_when_active(tmp_path: Path) -> None:
+    state_path = tmp_path / "telemetry.json"
+    payload = record_command(
+        _enabled_config(),
+        command="generate",
+        result="success",
+        duration_ms=42,
+        project_shape=ProjectShape(models=3, adapter_type="duckdb"),
+        consent="unset",
+        state_path=state_path,
+        send=False,
+    )
+    assert payload is not None
+    assert payload["command"] == "generate"
+    assert payload["result"] == "success"
+    assert payload["duration_ms"] == 42
+    assert payload["adapter_type"] == "duckdb"
+    assert payload["project_shape"]["models"] == 3
+    # Instance ID is generated and persisted
+    assert isinstance(payload["instance_id"], str)
+    assert state_path.exists()
+
+
+def test_record_command_uses_consent_from_state_file_when_not_passed(tmp_path: Path) -> None:
+    state_path = tmp_path / "telemetry.json"
+    state.set_consent("yes", state_path)
+    payload = record_command(
+        _disabled_config(),
+        command="health",
+        result="success",
+        duration_ms=10,
+        state_path=state_path,
+        send=False,
+    )
+    assert payload is not None  # consent=yes from state file activates dispatch
+
+
+def test_record_command_does_not_send_when_send_false(tmp_path: Path) -> None:
+    state_path = tmp_path / "telemetry.json"
+    with patch("docglow.telemetry.dispatcher.client.send") as mock_send:
+        record_command(
+            _enabled_config(),
+            command="generate",
+            result="success",
+            duration_ms=10,
+            consent="yes",
+            state_path=state_path,
+            send=False,
+        )
+    mock_send.assert_not_called()
+
+
+def test_record_command_sends_via_client_when_active(tmp_path: Path) -> None:
+    state_path = tmp_path / "telemetry.json"
+    with patch("docglow.telemetry.dispatcher.client.send") as mock_send:
+        record_command(
+            _enabled_config(),
+            command="generate",
+            result="success",
+            duration_ms=10,
+            consent="yes",
+            state_path=state_path,
+        )
+    mock_send.assert_called_once()
+    args, _kwargs = mock_send.call_args
+    payload, endpoint = args
+    assert payload["command"] == "generate"
+    assert endpoint == "http://localhost:1/telemetry"
+
+
+def test_record_command_swallows_internal_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state_path = tmp_path / "telemetry.json"
+
+    def boom(*_args, **_kwargs) -> None:
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr("docglow.telemetry.dispatcher.build_event", boom)
+    # Should not raise even though build_event explodes
+    payload = record_command(
+        _enabled_config(),
+        command="generate",
+        result="success",
+        duration_ms=10,
+        consent="yes",
+        state_path=state_path,
+    )
+    assert payload is None
+
+
+# ---- project_shape_from_manifest_path --------------------------------------
+
+
+def test_manifest_path_peek_missing_file_returns_zero(tmp_path: Path) -> None:
+    shape = project_shape_from_manifest_path(tmp_path)
+    assert shape == ProjectShape()
+
+
+def test_manifest_path_peek_corrupt_json_returns_zero(tmp_path: Path) -> None:
+    (tmp_path / "manifest.json").write_text("{not json", encoding="utf-8")
+    shape = project_shape_from_manifest_path(tmp_path)
+    assert shape == ProjectShape()
+
+
+def test_manifest_path_peek_counts_resource_types(tmp_path: Path) -> None:
+    manifest_data = {
+        "metadata": {"adapter_type": "Snowflake"},
+        "nodes": {
+            "model.x.a": {"resource_type": "model"},
+            "model.x.b": {"resource_type": "model"},
+            "test.x.t1": {"resource_type": "test"},
+            "seed.x.s1": {"resource_type": "seed"},
+            "snapshot.x.sn1": {"resource_type": "snapshot"},  # not counted
+        },
+        "sources": {"source.x.a": {}, "source.x.b": {}},
+        "macros": {"macro.x.m1": {}},
+    }
+    (tmp_path / "manifest.json").write_text(json.dumps(manifest_data), encoding="utf-8")
+    shape = project_shape_from_manifest_path(tmp_path)
+    assert shape.models == 2
+    assert shape.tests == 1
+    assert shape.seeds == 1
+    assert shape.sources == 2
+    assert shape.macros == 1
+    assert shape.adapter_type == "snowflake"
+
+
+def test_manifest_path_peek_missing_metadata_returns_none_adapter(tmp_path: Path) -> None:
+    (tmp_path / "manifest.json").write_text(
+        json.dumps({"nodes": {}, "sources": {}, "macros": {}}), encoding="utf-8"
+    )
+    shape = project_shape_from_manifest_path(tmp_path)
+    assert shape.adapter_type is None

--- a/tests/telemetry/test_payload.py
+++ b/tests/telemetry/test_payload.py
@@ -1,0 +1,196 @@
+"""Tests for docglow.telemetry.payload."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import pytest
+
+import docglow as _docglow
+from docglow.telemetry.payload import (
+    SCHEMA_VERSION,
+    ProjectShape,
+    build_event,
+)
+
+EXPECTED_KEYS = {
+    "schema_version",
+    "instance_id",
+    "command",
+    "result",
+    "duration_ms",
+    "docglow_version",
+    "python_version",
+    "platform",
+    "adapter_type",
+    "project_shape",
+    "features_used",
+}
+
+
+def _base_event(**overrides):
+    kwargs = dict(
+        instance_id="00000000-0000-0000-0000-000000000001",
+        command="generate",
+        result="success",
+        duration_ms=1234,
+        project_shape=ProjectShape(
+            models=10, sources=2, seeds=1, tests=5, macros=0, adapter_type="duckdb"
+        ),
+        features_used=("column_lineage",),
+    )
+    kwargs.update(overrides)
+    return build_event(**kwargs)
+
+
+def test_payload_keys_are_exactly_the_documented_set() -> None:
+    event = _base_event()
+    assert set(event.keys()) == EXPECTED_KEYS
+
+
+def test_payload_is_json_serialisable() -> None:
+    event = _base_event()
+    # Must round-trip cleanly; if a field is non-serialisable we want to know.
+    json.dumps(event)
+
+
+def test_schema_version_is_v1() -> None:
+    event = _base_event()
+    assert event["schema_version"] == SCHEMA_VERSION == 1
+
+
+def test_carries_through_known_fields() -> None:
+    event = _base_event()
+    assert event["instance_id"] == "00000000-0000-0000-0000-000000000001"
+    assert event["command"] == "generate"
+    assert event["result"] == "success"
+    assert event["duration_ms"] == 1234
+    assert event["docglow_version"] == _docglow.__version__
+    assert event["adapter_type"] == "duckdb"
+    assert event["features_used"] == ["column_lineage"]
+
+
+def test_python_version_is_dotted_triple() -> None:
+    event = _base_event()
+    parts = event["python_version"].split(".")
+    assert len(parts) == 3
+    assert all(p.isdigit() for p in parts)
+    assert parts[0] == str(sys.version_info.major)
+
+
+def test_platform_is_one_of_known_values() -> None:
+    event = _base_event()
+    assert event["platform"] in {"linux", "darwin", "windows", "other"}
+
+
+def test_empty_project_shape_yields_zero_counts() -> None:
+    event = build_event(
+        instance_id="x",
+        command="health",
+        result="success",
+        duration_ms=0,
+        project_shape=ProjectShape(),
+    )
+    assert event["project_shape"] == {
+        "models": 0,
+        "sources": 0,
+        "seeds": 0,
+        "tests": 0,
+        "macros": 0,
+    }
+    assert event["adapter_type"] is None
+
+
+def test_none_project_shape_treated_as_empty() -> None:
+    event = build_event(
+        instance_id="x",
+        command="serve",
+        result="success",
+        duration_ms=0,
+        project_shape=None,
+    )
+    assert event["project_shape"]["models"] == 0
+    assert event["adapter_type"] is None
+
+
+def test_adapter_type_null_is_present_not_omitted() -> None:
+    event = build_event(
+        instance_id="x",
+        command="generate",
+        result="success",
+        duration_ms=0,
+        project_shape=ProjectShape(),
+    )
+    assert "adapter_type" in event
+    assert event["adapter_type"] is None
+
+
+def test_features_used_empty_list_present_not_omitted() -> None:
+    event = build_event(
+        instance_id="x",
+        command="generate",
+        result="success",
+        duration_ms=0,
+        project_shape=None,
+    )
+    assert "features_used" in event
+    assert event["features_used"] == []
+
+
+def test_duration_ms_coerced_to_int() -> None:
+    event = build_event(
+        instance_id="x",
+        command="generate",
+        result="success",
+        duration_ms=42.7,  # type: ignore[arg-type]
+        project_shape=None,
+    )
+    assert event["duration_ms"] == 42
+    assert isinstance(event["duration_ms"], int)
+
+
+@pytest.mark.parametrize("command", ["generate", "health", "serve"])
+def test_all_documented_commands_accepted(command: str) -> None:
+    event = build_event(
+        instance_id="x",
+        command=command,  # type: ignore[arg-type]
+        result="success",
+        duration_ms=0,
+        project_shape=None,
+    )
+    assert event["command"] == command
+
+
+@pytest.mark.parametrize("result", ["success", "error"])
+def test_all_documented_results_accepted(result: str) -> None:
+    event = build_event(
+        instance_id="x",
+        command="generate",
+        result=result,  # type: ignore[arg-type]
+        duration_ms=0,
+        project_shape=None,
+    )
+    assert event["result"] == result
+
+
+def test_snapshot_pins_v1_shape() -> None:
+    """Snapshot test -- a deliberate change to the payload shape must update this.
+
+    This is the load-bearing test against accidental schema drift. If a new
+    field is added without updating docs/telemetry.md, this test will fail
+    and force a conscious decision about what's being shipped.
+    """
+    event = build_event(
+        instance_id="00000000-0000-0000-0000-000000000001",
+        command="generate",
+        result="success",
+        duration_ms=4218,
+        project_shape=ProjectShape(
+            models=142, sources=31, seeds=4, tests=213, macros=8, adapter_type="snowflake"
+        ),
+        features_used=("column_lineage", "health_score"),
+    )
+    # Pin the keys (values like docglow_version, python_version, platform vary).
+    assert set(event.keys()) == EXPECTED_KEYS
+    assert set(event["project_shape"].keys()) == {"models", "sources", "seeds", "tests", "macros"}

--- a/tests/telemetry/test_state.py
+++ b/tests/telemetry/test_state.py
@@ -1,0 +1,146 @@
+"""Tests for docglow.telemetry.state."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+
+import pytest
+
+from docglow.telemetry import state
+
+
+@pytest.fixture
+def state_path(tmp_path: Path) -> Path:
+    return tmp_path / "telemetry.json"
+
+
+def test_get_instance_id_generates_and_persists(state_path: Path) -> None:
+    assert not state_path.exists()
+    instance_id = state.get_instance_id(state_path)
+    uuid.UUID(instance_id)  # raises if not a valid UUID
+    assert state_path.exists()
+    payload = json.loads(state_path.read_text())
+    assert payload["instance_id"] == instance_id
+    assert payload["version"] == state.STATE_VERSION
+    assert payload["consent"] == "unset"
+
+
+def test_get_instance_id_is_stable_across_calls(state_path: Path) -> None:
+    first = state.get_instance_id(state_path)
+    second = state.get_instance_id(state_path)
+    third = state.get_instance_id(state_path)
+    assert first == second == third
+
+
+def test_get_instance_id_recovers_from_corrupt_json(state_path: Path) -> None:
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text("{not valid json", encoding="utf-8")
+    instance_id = state.get_instance_id(state_path)
+    uuid.UUID(instance_id)
+    # File should now contain a valid payload
+    payload = json.loads(state_path.read_text())
+    assert payload["instance_id"] == instance_id
+
+
+def test_get_instance_id_recovers_from_unknown_version(state_path: Path) -> None:
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(json.dumps({"version": 999, "instance_id": "leftover"}), encoding="utf-8")
+    instance_id = state.get_instance_id(state_path)
+    uuid.UUID(instance_id)
+    assert instance_id != "leftover"
+
+
+def test_get_instance_id_recovers_from_invalid_uuid(state_path: Path) -> None:
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        json.dumps({"version": state.STATE_VERSION, "instance_id": "not-a-uuid"}),
+        encoding="utf-8",
+    )
+    instance_id = state.get_instance_id(state_path)
+    uuid.UUID(instance_id)
+    assert instance_id != "not-a-uuid"
+
+
+def test_get_instance_id_when_directory_unwritable_does_not_raise(
+    state_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Force write failures by pointing to an unwritable path
+    bad_path = state_path / "telemetry.json"  # parent is a file that doesn't exist
+    state_path.write_text("blocker")  # makes state_path a file, so bad_path's parent IS a file
+
+    # Should not raise even though writes will fail
+    instance_id = state.get_instance_id(bad_path)
+    uuid.UUID(instance_id)
+
+
+def test_get_consent_default_is_unset(state_path: Path) -> None:
+    assert state.get_consent(state_path) == "unset"
+
+
+def test_set_consent_yes(state_path: Path) -> None:
+    state.set_consent("yes", state_path)
+    assert state.get_consent(state_path) == "yes"
+    payload = json.loads(state_path.read_text())
+    assert "consent_recorded_at" in payload
+    uuid.UUID(payload["instance_id"])
+
+
+def test_set_consent_no(state_path: Path) -> None:
+    state.set_consent("no", state_path)
+    assert state.get_consent(state_path) == "no"
+    payload = json.loads(state_path.read_text())
+    assert "consent_recorded_at" in payload
+
+
+def test_set_consent_preserves_instance_id(state_path: Path) -> None:
+    instance_id = state.get_instance_id(state_path)
+    state.set_consent("yes", state_path)
+    state.set_consent("no", state_path)
+    payload = json.loads(state_path.read_text())
+    assert payload["instance_id"] == instance_id
+
+
+def test_set_consent_generates_instance_id_when_missing(state_path: Path) -> None:
+    assert not state_path.exists()
+    state.set_consent("yes", state_path)
+    payload = json.loads(state_path.read_text())
+    uuid.UUID(payload["instance_id"])
+
+
+def test_set_consent_unset_clears_recorded_at(state_path: Path) -> None:
+    state.set_consent("yes", state_path)
+    state.set_consent("unset", state_path)
+    payload = json.loads(state_path.read_text())
+    assert payload["consent"] == "unset"
+    assert "consent_recorded_at" not in payload
+
+
+def test_set_consent_rejects_invalid_value(state_path: Path) -> None:
+    with pytest.raises(ValueError):
+        state.set_consent("maybe", state_path)  # type: ignore[arg-type]
+
+
+def test_get_consent_normalizes_unknown_value(state_path: Path) -> None:
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        json.dumps(
+            {
+                "version": state.STATE_VERSION,
+                "instance_id": str(uuid.uuid4()),
+                "consent": "maybe",
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert state.get_consent(state_path) == "unset"
+
+
+def test_default_path_uses_click_app_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        "docglow.telemetry.state.click.get_app_dir",
+        lambda _name: str(tmp_path / "appdir"),
+    )
+    p = state._state_path()
+    assert p == tmp_path / "appdir" / state.STATE_FILENAME

--- a/tests/test_cli_telemetry.py
+++ b/tests/test_cli_telemetry.py
@@ -1,0 +1,173 @@
+"""Tests for docglow telemetry status|enable|disable subcommands and the
+first-run consent prompt.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from docglow.cli import cli
+from docglow.commands.telemetry import maybe_prompt_for_consent
+from docglow.telemetry import state
+
+
+@pytest.fixture(autouse=True)
+def isolated_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    state_path = tmp_path / "telemetry.json"
+    monkeypatch.setattr(state, "_state_path", lambda: state_path)
+    monkeypatch.delenv("DOCGLOW_TELEMETRY", raising=False)
+    monkeypatch.delenv("DOCGLOW_NO_TELEMETRY", raising=False)
+    monkeypatch.delenv("DOCGLOW_TELEMETRY_ENDPOINT", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    return state_path
+
+
+# ---- subcommands -----------------------------------------------------------
+
+
+def test_telemetry_status_default_is_inactive(isolated_state: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["telemetry", "status"])
+    assert result.exit_code == 0
+    assert "Active: no" in result.output
+    assert "Recorded consent: unset" in result.output
+
+
+def test_telemetry_enable_records_consent(isolated_state: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["telemetry", "enable"])
+    assert result.exit_code == 0
+    assert state.get_consent(isolated_state) == "yes"
+
+    result = runner.invoke(cli, ["telemetry", "status"])
+    assert "Active: yes" in result.output
+    assert "Recorded consent: yes" in result.output
+
+
+def test_telemetry_disable_records_consent(isolated_state: Path) -> None:
+    runner = CliRunner()
+    state.set_consent("yes", isolated_state)
+
+    result = runner.invoke(cli, ["telemetry", "disable"])
+    assert result.exit_code == 0
+    assert state.get_consent(isolated_state) == "no"
+
+    result = runner.invoke(cli, ["telemetry", "status"])
+    assert "Active: no" in result.output
+    assert "Recorded consent: no" in result.output
+
+
+def test_telemetry_status_reflects_no_telemetry_env_override(
+    isolated_state: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state.set_consent("yes", isolated_state)
+    monkeypatch.setenv("DOCGLOW_NO_TELEMETRY", "1")
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["telemetry", "status"])
+    assert "Active: no" in result.output
+
+
+def test_telemetry_status_shows_endpoint_override(
+    isolated_state: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DOCGLOW_TELEMETRY_ENDPOINT", "https://override.test/")
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["telemetry", "status"])
+    assert "https://override.test/" in result.output
+
+
+def test_telemetry_status_shows_instance_id(isolated_state: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["telemetry", "status"])
+    assert result.exit_code == 0
+    # Instance ID line is present
+    assert "Instance ID:" in result.output
+
+
+# ---- consent prompt --------------------------------------------------------
+
+
+def test_prompt_skipped_when_ci_env_set(
+    isolated_state: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CI", "true")
+    consent = maybe_prompt_for_consent()
+    # Consent was recorded as "no" so we never re-prompt
+    assert consent == "no"
+    assert state.get_consent(isolated_state) == "no"
+
+
+def test_prompt_skipped_when_stdin_not_tty(
+    isolated_state: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # In test contexts stdin is typically not a TTY, so the prompt should
+    # be suppressed and consent recorded as "no".
+    consent = maybe_prompt_for_consent()
+    assert consent == "no"
+    assert state.get_consent(isolated_state) == "no"
+
+
+def test_prompt_skipped_when_no_telemetry_env_set(
+    isolated_state: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DOCGLOW_NO_TELEMETRY", "1")
+    consent = maybe_prompt_for_consent()
+    assert consent == "no"
+
+
+def test_prompt_not_shown_again_after_decision(
+    isolated_state: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state.set_consent("yes", isolated_state)
+    # Even with a TTY, an existing consent value short-circuits the prompt.
+    consent = maybe_prompt_for_consent()
+    assert consent == "yes"
+
+
+def test_prompt_does_not_overwrite_explicit_no(
+    isolated_state: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state.set_consent("no", isolated_state)
+    consent = maybe_prompt_for_consent()
+    assert consent == "no"
+
+
+# ---- generate runs the prompt only when consent is unset -------------------
+
+
+def test_generate_records_implicit_no_consent_when_non_interactive(
+    isolated_state: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Running generate non-interactively should record consent=no automatically."""
+    from unittest.mock import MagicMock, patch
+
+    from docglow.telemetry.config import TelemetryConfig
+
+    monkeypatch.setenv("DOCGLOW_NO_CLOUD_HINT", "1")
+
+    mock_config = MagicMock()
+    mock_config.ai.enabled = False
+    mock_config.title = "docglow"
+    mock_config.slim = False
+    mock_config.column_lineage = True
+    mock_config.telemetry = TelemetryConfig(enabled=False, endpoint="http://localhost:1/telemetry")
+
+    runner = CliRunner()
+    with (
+        patch("docglow.config.load_config", return_value=mock_config),
+        patch(
+            "docglow.generator.site.generate_site",
+            return_value=(tmp_path / "output", 85.0),
+        ),
+    ):
+        result = runner.invoke(cli, ["generate", "--project-dir", str(tmp_path)])
+
+    assert result.exit_code == 0
+    # The prompt was suppressed in the non-TTY runner context, so consent
+    # should have flipped from "unset" to "no".
+    assert state.get_consent(isolated_state) == "no"

--- a/tests/test_cli_telemetry_e2e.py
+++ b/tests/test_cli_telemetry_e2e.py
@@ -1,0 +1,210 @@
+"""End-to-end test: opt-in flow against a stub HTTP server.
+
+Exercises the full chain CLI -> dispatcher -> client -> network. The
+generate command is patched at the generate_site boundary (the heavy lift
+is not what we're testing), but every layer of telemetry is real.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from docglow import cloud_hint
+from docglow.cli import cli
+from docglow.telemetry import state
+from docglow.telemetry.config import TelemetryConfig
+
+
+class _CapturingServer:
+    """Thread-backed HTTP server that records POST bodies."""
+
+    def __init__(self, response_status: int = 204) -> None:
+        self.received: list[dict[str, Any]] = []
+        self.response_status = response_status
+        outer = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def log_message(self, *_args: Any) -> None:
+                return
+
+            def do_POST(self) -> None:  # noqa: N802
+                length = int(self.headers.get("Content-Length", "0"))
+                body = self.rfile.read(length)
+                try:
+                    payload = json.loads(body.decode("utf-8"))
+                except Exception:
+                    payload = {"_raw": body.decode("utf-8", "replace")}
+                outer.received.append(payload)
+                self.send_response(outer.response_status)
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+
+        self.server = HTTPServer(("127.0.0.1", 0), Handler)
+        self.url = f"http://127.0.0.1:{self.server.server_address[1]}/v1/telemetry/events"
+        self._thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+
+    def __enter__(self) -> _CapturingServer:
+        self._thread.start()
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+
+
+def _wait_for_event(stub: _CapturingServer, timeout: float = 3.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline and not stub.received:
+        time.sleep(0.02)
+
+
+@pytest.fixture(autouse=True)
+def isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    state_path = tmp_path / "telemetry.json"
+    monkeypatch.setattr(state, "_state_path", lambda: state_path)
+    cloud_hint_state = tmp_path / "cloud_hint.json"
+    monkeypatch.setattr(cloud_hint, "_state_path", lambda: cloud_hint_state)
+    monkeypatch.setenv("DOCGLOW_NO_CLOUD_HINT", "1")
+    monkeypatch.delenv("DOCGLOW_TELEMETRY", raising=False)
+    monkeypatch.delenv("DOCGLOW_NO_TELEMETRY", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    return state_path
+
+
+def _mock_config(endpoint: str, *, enabled: bool) -> MagicMock:
+    config = MagicMock()
+    config.ai.enabled = False
+    config.title = "docglow"
+    config.slim = False
+    config.column_lineage = True
+    config.telemetry = TelemetryConfig(enabled=enabled, endpoint=endpoint)
+    return config
+
+
+def test_e2e_enabled_generates_one_event(tmp_path: Path) -> None:
+    runner = CliRunner()
+    with _CapturingServer() as stub:
+        with (
+            patch(
+                "docglow.config.load_config",
+                return_value=_mock_config(stub.url, enabled=True),
+            ),
+            patch(
+                "docglow.generator.site.generate_site",
+                return_value=(tmp_path / "output", 85.0),
+            ),
+        ):
+            result = runner.invoke(cli, ["generate", "--project-dir", str(tmp_path)])
+
+        assert result.exit_code == 0, result.output
+        _wait_for_event(stub)
+
+    assert len(stub.received) == 1
+    event = stub.received[0]
+    assert event["command"] == "generate"
+    assert event["result"] == "success"
+    assert event["schema_version"] == 1
+    assert "instance_id" in event
+    assert "duration_ms" in event
+
+
+def test_e2e_disabled_sends_no_event(tmp_path: Path) -> None:
+    runner = CliRunner()
+    with _CapturingServer() as stub:
+        with (
+            patch(
+                "docglow.config.load_config",
+                return_value=_mock_config(stub.url, enabled=False),
+            ),
+            patch(
+                "docglow.generator.site.generate_site",
+                return_value=(tmp_path / "output", 85.0),
+            ),
+        ):
+            result = runner.invoke(cli, ["generate", "--project-dir", str(tmp_path)])
+
+        assert result.exit_code == 0, result.output
+        # Wait briefly to be sure no event arrives late
+        time.sleep(0.2)
+
+    assert stub.received == []
+
+
+def test_e2e_server_500_does_not_break_generate(tmp_path: Path) -> None:
+    """Telemetry server failure must not affect the user's exit code."""
+    runner = CliRunner()
+    with _CapturingServer(response_status=500) as stub:
+        with (
+            patch(
+                "docglow.config.load_config",
+                return_value=_mock_config(stub.url, enabled=True),
+            ),
+            patch(
+                "docglow.generator.site.generate_site",
+                return_value=(tmp_path / "output", 85.0),
+            ),
+        ):
+            result = runner.invoke(cli, ["generate", "--project-dir", str(tmp_path)])
+
+        _wait_for_event(stub)
+
+    # Generate succeeded even though the server rejected the event
+    assert result.exit_code == 0, result.output
+    # Server still received the attempt
+    assert len(stub.received) == 1
+
+
+def test_e2e_unreachable_endpoint_does_not_break_generate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Endpoint completely unreachable must not affect the user's exit code."""
+    unreachable = "http://127.0.0.1:1/v1/telemetry/events"
+    runner = CliRunner()
+    with (
+        patch(
+            "docglow.config.load_config",
+            return_value=_mock_config(unreachable, enabled=True),
+        ),
+        patch(
+            "docglow.generator.site.generate_site",
+            return_value=(tmp_path / "output", 85.0),
+        ),
+    ):
+        result = runner.invoke(cli, ["generate", "--project-dir", str(tmp_path)])
+
+    assert result.exit_code == 0, result.output
+
+
+def test_e2e_consent_yes_in_state_file_activates_send(tmp_path: Path, isolated: Path) -> None:
+    """User who ran `docglow telemetry enable` should see telemetry fire even
+    when no env vars or yml flag is set.
+    """
+    state.set_consent("yes", isolated)
+
+    runner = CliRunner()
+    with _CapturingServer() as stub:
+        with (
+            patch(
+                "docglow.config.load_config",
+                return_value=_mock_config(stub.url, enabled=False),
+            ),
+            patch(
+                "docglow.generator.site.generate_site",
+                return_value=(tmp_path / "output", 85.0),
+            ),
+        ):
+            result = runner.invoke(cli, ["generate", "--project-dir", str(tmp_path)])
+
+        assert result.exit_code == 0, result.output
+        _wait_for_event(stub)
+
+    assert len(stub.received) == 1

--- a/tests/test_cli_telemetry_integration.py
+++ b/tests/test_cli_telemetry_integration.py
@@ -1,0 +1,143 @@
+"""Integration tests verifying telemetry dispatch from CLI commands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from docglow import cloud_hint
+from docglow.cli import cli
+from docglow.telemetry.config import TelemetryConfig
+
+
+def _mock_config(telemetry_enabled: bool = False) -> MagicMock:
+    config = MagicMock()
+    config.ai.enabled = False
+    config.title = "docglow"
+    config.slim = False
+    config.column_lineage = True
+    config.telemetry = TelemetryConfig(
+        enabled=telemetry_enabled, endpoint="http://localhost:1/telemetry"
+    )
+    return config
+
+
+@pytest.fixture(autouse=True)
+def isolated_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    state = tmp_path / "cloud_hint.json"
+    monkeypatch.setattr(cloud_hint, "_state_path", lambda: state)
+    monkeypatch.setenv("DOCGLOW_NO_CLOUD_HINT", "1")
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.delenv("DOCGLOW_TELEMETRY", raising=False)
+    monkeypatch.delenv("DOCGLOW_NO_TELEMETRY", raising=False)
+
+
+def test_generate_records_success_event_when_telemetry_enabled(tmp_path: Path) -> None:
+    runner = CliRunner()
+    with (
+        patch("docglow.config.load_config", return_value=_mock_config(telemetry_enabled=True)),
+        patch(
+            "docglow.generator.site.generate_site",
+            return_value=(tmp_path / "output", 85.0),
+        ),
+        patch("docglow.telemetry.dispatcher.record_command") as mock_record,
+    ):
+        result = runner.invoke(cli, ["generate", "--project-dir", str(tmp_path)])
+
+    assert result.exit_code == 0, result.output
+    mock_record.assert_called_once()
+    kwargs = mock_record.call_args.kwargs
+    assert kwargs["command"] == "generate"
+    assert kwargs["result"] == "success"
+    assert "duration_ms" in kwargs
+    assert isinstance(kwargs["duration_ms"], int)
+
+
+def test_generate_records_error_event_on_failure(tmp_path: Path) -> None:
+    from docglow.artifacts.loader import ArtifactLoadError
+
+    runner = CliRunner()
+    with (
+        patch("docglow.config.load_config", return_value=_mock_config(telemetry_enabled=True)),
+        patch(
+            "docglow.generator.site.generate_site",
+            side_effect=ArtifactLoadError("manifest missing"),
+        ),
+        patch("docglow.telemetry.dispatcher.record_command") as mock_record,
+    ):
+        result = runner.invoke(cli, ["generate", "--project-dir", str(tmp_path)])
+
+    assert result.exit_code == 1
+    mock_record.assert_called_once()
+    assert mock_record.call_args.kwargs["result"] == "error"
+
+
+def test_generate_records_error_when_fail_under_trips(tmp_path: Path) -> None:
+    runner = CliRunner()
+    with (
+        patch("docglow.config.load_config", return_value=_mock_config(telemetry_enabled=True)),
+        patch(
+            "docglow.generator.site.generate_site",
+            return_value=(tmp_path / "output", 40.0),
+        ),
+        patch("docglow.telemetry.dispatcher.record_command") as mock_record,
+    ):
+        result = runner.invoke(
+            cli, ["generate", "--project-dir", str(tmp_path), "--fail-under", "70"]
+        )
+
+    assert result.exit_code == 1
+    mock_record.assert_called_once()
+    assert mock_record.call_args.kwargs["result"] == "error"
+
+
+def test_generate_dispatcher_still_called_when_telemetry_disabled(tmp_path: Path) -> None:
+    """When disabled, record_command is still invoked but is internally a no-op.
+
+    The gate logic lives inside record_command, not at the call site -- this
+    keeps the command-level wiring trivial and centralises the gate.
+    """
+    runner = CliRunner()
+    with (
+        patch("docglow.config.load_config", return_value=_mock_config(telemetry_enabled=False)),
+        patch(
+            "docglow.generator.site.generate_site",
+            return_value=(tmp_path / "output", 85.0),
+        ),
+        patch("docglow.telemetry.dispatcher.record_command") as mock_record,
+    ):
+        result = runner.invoke(cli, ["generate", "--project-dir", str(tmp_path)])
+
+    assert result.exit_code == 0
+    mock_record.assert_called_once()
+
+
+def test_generate_features_used_reflects_active_flags(tmp_path: Path) -> None:
+    runner = CliRunner()
+    with (
+        patch("docglow.config.load_config", return_value=_mock_config(telemetry_enabled=True)),
+        patch(
+            "docglow.generator.site.generate_site",
+            return_value=(tmp_path / "output", 85.0),
+        ),
+        patch("docglow.telemetry.dispatcher.record_command") as mock_record,
+    ):
+        runner.invoke(
+            cli,
+            [
+                "generate",
+                "--project-dir",
+                str(tmp_path),
+                "--static",
+                "--slim",
+                "--skip-column-lineage",
+            ],
+        )
+
+    features = mock_record.call_args.kwargs["features_used"]
+    assert "column_lineage" not in features
+    assert "static" in features
+    assert "slim" in features


### PR DESCRIPTION
Closes [DOC-196](https://linear.app/docglow/issue/DOC-196) and [DOC-203](https://linear.app/docglow/issue/DOC-203). Resolves #24.

Adds opt-in anonymous telemetry to the Docglow CLI so maintainers can see which dbt adapters and project sizes are in use, without compromising user privacy. Off by default. Smoke-tested end-to-end against the staging receiver on `api-staging.docglow.com` before this PR was opened — rows landed, kill switch verified.

## What ships in this PR

### Core feature
- `src/docglow/telemetry/` — new package: `config` (env-var precedence resolver), `state` (UUID4 instance ID + tri-state consent in `click.get_app_dir("docglow")/telemetry.json`), `payload` (allow-list builder + snapshot test pinning v1 shape), `client` (stdlib `urllib.request` fire-and-forget transport), `dispatcher` (`record_command()` + `is_active()` gate, lightweight manifest peek for projects without a loaded `Manifest`).
- `src/docglow/commands/telemetry.py` — `docglow telemetry status|enable|disable` subcommand group + first-run consent prompt that fires once on interactive `docglow generate` (default-no on Enter / non-TTY / `CI=true`).
- Wired into `generate`, `health`, `serve` via `try`/`finally`. `serve` emits at startup so a Ctrl+C'd long-running session still records the launch.
- `docs/telemetry.md` — public canonical privacy contract listing the exact v1 payload and every control. Linked from `README.md` and `mkdocs.yml`.

### Privacy contract
- Two opt-in paths converge on a single `is_active()` gate: `DOCGLOW_TELEMETRY=1` (or `telemetry.enabled: true` in `docglow.yml`) for power users, first-run consent prompt for typical users. `DOCGLOW_NO_TELEMETRY=1` overrides both.
- Allow-list `build_event()` — no kwargs passthrough; a snapshot test pins exact payload keys so adding a field requires a deliberate update + matching `docs/telemetry.md` change.
- Every code path swallows exceptions at the public-API boundary. Telemetry must never break the calling CLI command.

### Production endpoint (DOC-203)
- `DEFAULT_ENDPOINT` set to `https://api.docglow.com/v1/telemetry/events` (the cloud receiver shipped on the `.com` TLD, not the `.dev` TLD originally referenced).
- Override with `DOCGLOW_TELEMETRY_ENDPOINT` (e.g. `https://api-staging.docglow.com/...` for staging smoke).

### Reliability fixes surfaced during staging smoke
- **Drain in-flight sends at process exit.** Daemon-thread sends were being killed mid-TLS when the CLI exited within tens of ms of dispatching telemetry. New `atexit` hook joins pending threads with a shared 2.5s budget; per-request `urlopen` timeout is still authoritative.
- **Follow 307/308 redirects on POST.** Stdlib `urllib.request.HTTPRedirectHandler` raises `HTTPError` on POST + 307 by default; mirrors httpx's `follow_redirects=True` behaviour from the cloud client.
- **Drop `x-vercel-set-bypass-cookie: true` from staging-bypass requests.** Vercel's cookie-bypass flow returns a 307 + Set-Cookie expecting the client to carry the cookie; stdlib urllib has no cookie jar so it produces an unbreakable redirect loop. `x-vercel-protection-bypass` alone is sufficient for fire-and-forget.

### Diagnostics
- `DOCGLOW_TELEMETRY_DEBUG=1` writes one line per send (and one per redirect hop) to stderr, bypassing logger config so visibility doesn't depend on which subcommand was invoked. Documented in `docs/telemetry.md` under Troubleshooting.

## Test plan

- [x] 115 telemetry unit tests; 713 total pytest passing
- [x] ruff lint, ruff format, mypy clean across `src/docglow` (74 source files)
- [x] Snapshot test pins v1 payload shape — adding a key requires deliberate update
- [x] Env-var precedence matrix: `DOCGLOW_NO_TELEMETRY` > `DOCGLOW_TELEMETRY` > yml > default
- [x] State file robustness: corrupt JSON, unknown version, invalid UUID, unwritable dir — none raise
- [x] Transport: 204/4xx/5xx, connection refused, timeout, async-doesn't-block, 307/308 redirect-follow with body preservation
- [x] Dispatcher: gate combinations, missing manifest, internal exception swallowed
- [x] E2E test against thread-backed stub HTTPServer
- [x] Live staging smoke against `api-staging.docglow.com`: opt-in produces one row per command (`generate` + `health`); `DOCGLOW_NO_TELEMETRY=1` produces zero rows

## Pre-merge checks

- [ ] CI green
- [ ] One last production smoke after merge (drop staging override env vars, opt in once, verify one row in production `telemetry.events`)