### PR TITLE
telemetry follow-ups: HTTPS-only endpoint + record() refactor

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -125,6 +125,8 @@ That command prints whether telemetry is currently active, your machine-level in
 
 Events are sent over HTTPS to the Docglow Cloud API at `api.docglow.com`. Rows land in a Postgres table managed via Supabase, accessible only to Docglow maintainers. We retain raw events for 365 days; aggregates may be kept longer.
 
+The endpoint can be overridden via `DOCGLOW_TELEMETRY_ENDPOINT` (or `telemetry.endpoint` in `docglow.yml`) for self-hosted receivers or staging environments. Only `https://` URLs are accepted; plaintext `http://` is silently rejected and falls back to the default — except `http://localhost` and `http://127.0.0.1` for local development. This prevents a misconfigured config from routing payloads (and any deployment-protection bypass token you have set) over an unencrypted channel.
+
 If you want a particular `instance_id`'s data deleted, open an issue on [docglow/docglow](https://github.com/docglow/docglow/issues) with the ID and we'll purge it.
 
 ## Troubleshooting

--- a/src/docglow/commands/generate.py
+++ b/src/docglow/commands/generate.py
@@ -1,6 +1,5 @@
 """Generate command for docglow CLI."""
 
-import time
 from pathlib import Path
 
 import click
@@ -163,16 +162,11 @@ def generate(
     if profile and profile_adapter and profile_connection:
         profiling_connection = _parse_connection(profile_adapter, profile_connection)
 
-    # Telemetry setup -- dispatched in the finally block so success/error and
-    # duration are recorded regardless of how the command exits. The first-run
-    # consent prompt fires here (before the long generate work) when the
-    # context is interactive and consent has not yet been recorded.
     from docglow.commands.telemetry import maybe_prompt_for_consent
     from docglow.telemetry import dispatcher as telemetry
 
     maybe_prompt_for_consent(console)
 
-    telemetry_started = time.monotonic()
     telemetry_features: list[str] = []
     if column_lineage:
         telemetry_features.append("column_lineage")
@@ -185,64 +179,61 @@ def generate(
     if slim:
         telemetry_features.append("slim")
     telemetry_resolved_target = target_dir or (project_dir / "target")
-    telemetry_result_name = "error"
 
-    try:
-        output_path, health_score = generate_site(
-            project_dir=project_dir,
-            target_dir=target_dir,
-            output_dir=output_dir,
-            static=static,
-            profiling_enabled=profile,
-            profiling_adapter=profile_adapter,
-            profiling_connection=profiling_connection,
-            profiling_sample_size=profile_sample_size,
-            profiling_cache=not profile_no_cache,
-            ai_enabled=ai,
-            title=title,
-            select=select,
-            exclude=exclude,
-            column_lineage_enabled=column_lineage,
-            column_lineage_select=column_lineage_select,
-            column_lineage_depth=column_lineage_depth,
-            exclude_packages=not include_packages,
-            slim=slim,
-            head_script=head_script.read_text(encoding="utf-8") if head_script else None,
-            column_lineage_workers=workers,
-        )
-        console.print(f"\n[bold green]Site generated at {output_path}[/bold green]")
-        if static:
-            console.print("  Single-file mode: open index.html directly in a browser")
-        else:
-            console.print("  Run [bold]docglow serve[/bold] to view locally")
-
-        if fail_under is not None:
-            if health_score < fail_under:
-                console.print(
-                    f"\n[bold red]Health score {health_score:.0f} is below "
-                    f"threshold {fail_under:.0f}[/bold red]"
-                )
-                raise SystemExit(1)
+    with telemetry.record(
+        config.telemetry,
+        command="generate",
+        shape_provider=lambda: telemetry.project_shape_from_manifest_path(
+            telemetry_resolved_target
+        ),
+        features_used=tuple(telemetry_features),
+    ):
+        try:
+            output_path, health_score = generate_site(
+                project_dir=project_dir,
+                target_dir=target_dir,
+                output_dir=output_dir,
+                static=static,
+                profiling_enabled=profile,
+                profiling_adapter=profile_adapter,
+                profiling_connection=profiling_connection,
+                profiling_sample_size=profile_sample_size,
+                profiling_cache=not profile_no_cache,
+                ai_enabled=ai,
+                title=title,
+                select=select,
+                exclude=exclude,
+                column_lineage_enabled=column_lineage,
+                column_lineage_select=column_lineage_select,
+                column_lineage_depth=column_lineage_depth,
+                exclude_packages=not include_packages,
+                slim=slim,
+                head_script=head_script.read_text(encoding="utf-8") if head_script else None,
+                column_lineage_workers=workers,
+            )
+            console.print(f"\n[bold green]Site generated at {output_path}[/bold green]")
+            if static:
+                console.print("  Single-file mode: open index.html directly in a browser")
             else:
-                console.print(
-                    f"\n[bold green]Health score: {health_score:.0f} "
-                    f"(threshold: {fail_under:.0f})[/bold green]"
-                )
+                console.print("  Run [bold]docglow serve[/bold] to view locally")
 
-        maybe_show_hint(console, __version__)
-        telemetry_result_name = "success"
-    except ArtifactLoadError as e:
-        console.print(f"[bold red]Error:[/bold red] {e}")
-        raise SystemExit(1) from e
-    except FileNotFoundError as e:
-        console.print(f"[bold red]Error:[/bold red] {e}")
-        raise SystemExit(1) from e
-    finally:
-        telemetry.record_command(
-            config.telemetry,
-            command="generate",
-            result=telemetry_result_name,  # type: ignore[arg-type]
-            duration_ms=int((time.monotonic() - telemetry_started) * 1000),
-            project_shape=telemetry.project_shape_from_manifest_path(telemetry_resolved_target),
-            features_used=tuple(telemetry_features),
-        )
+            if fail_under is not None:
+                if health_score < fail_under:
+                    console.print(
+                        f"\n[bold red]Health score {health_score:.0f} is below "
+                        f"threshold {fail_under:.0f}[/bold red]"
+                    )
+                    raise SystemExit(1)
+                else:
+                    console.print(
+                        f"\n[bold green]Health score: {health_score:.0f} "
+                        f"(threshold: {fail_under:.0f})[/bold green]"
+                    )
+
+            maybe_show_hint(console, __version__)
+        except ArtifactLoadError as e:
+            console.print(f"[bold red]Error:[/bold red] {e}")
+            raise SystemExit(1) from e
+        except FileNotFoundError as e:
+            console.print(f"[bold red]Error:[/bold red] {e}")
+            raise SystemExit(1) from e

--- a/src/docglow/commands/health.py
+++ b/src/docglow/commands/health.py
@@ -1,6 +1,5 @@
 """Health command for docglow CLI."""
 
-import time
 from pathlib import Path
 
 import click
@@ -41,18 +40,21 @@ def health(
     from docglow.telemetry import dispatcher as telemetry
 
     config = load_config(project_dir)
-    telemetry_started = time.monotonic()
-    telemetry_result_name = "error"
-    telemetry_manifest = None
+    loaded_manifest = None
 
-    try:
+    with telemetry.record(
+        config.telemetry,
+        command="health",
+        shape_provider=lambda: telemetry.project_shape_from_manifest(loaded_manifest),
+        features_used=(output_format,),
+    ):
         try:
             artifacts = load_artifacts(project_dir, target_dir)
         except ArtifactLoadError as e:
             console.print(f"[bold red]Error:[/bold red] {e}")
             raise SystemExit(1) from e
 
-        telemetry_manifest = artifacts.manifest
+        loaded_manifest = artifacts.manifest
 
         # Build data to get transformed models/sources
         data = build_docglow_data(artifacts)
@@ -67,7 +69,6 @@ def health(
                     f"threshold {fail_under:.0f}[/bold red]"
                 )
                 raise SystemExit(1)
-            telemetry_result_name = "success"
             return
 
         if output_format == "markdown":
@@ -115,7 +116,6 @@ def health(
                     f"threshold {fail_under:.0f}[/bold red]"
                 )
                 raise SystemExit(1)
-            telemetry_result_name = "success"
             return
 
         # Table output
@@ -182,13 +182,3 @@ def health(
                 f"threshold {fail_under:.0f}[/bold red]"
             )
             raise SystemExit(1)
-        telemetry_result_name = "success"
-    finally:
-        telemetry.record_command(
-            config.telemetry,
-            command="health",
-            result=telemetry_result_name,  # type: ignore[arg-type]
-            duration_ms=int((time.monotonic() - telemetry_started) * 1000),
-            manifest=telemetry_manifest,
-            features_used=(output_format,),
-        )

--- a/src/docglow/commands/serve.py
+++ b/src/docglow/commands/serve.py
@@ -69,23 +69,22 @@ def serve(
         console.print("  Verbose: request logging enabled")
     console.print("  Press [bold]Ctrl+C[/bold] to stop\n")
 
-    # Telemetry: emit at startup -- a serve session may run for hours and a
-    # shutdown event would be lost on Ctrl+C. We record startup as "success"
-    # because the server is about to start blocking; failure to start would
-    # raise inside start_server below.
+    # Emit at startup, not shutdown: a serve session may run for hours, and
+    # the event would be lost on Ctrl+C.
     from docglow.config import load_config
     from docglow.telemetry import dispatcher as telemetry
+    from docglow.telemetry import state
 
     serve_config = load_config(project_dir)
-    telemetry_features: tuple[str, ...] = ("watch",) if watch else ()
-    telemetry.record_command(
-        serve_config.telemetry,
-        command="serve",
-        result="success",
-        duration_ms=0,
-        project_shape=telemetry.project_shape_from_manifest_path(project_dir / "target"),
-        features_used=telemetry_features,
-    )
+    if telemetry.is_active(serve_config.telemetry, state.get_consent()):
+        telemetry.record_command(
+            serve_config.telemetry,
+            command="serve",
+            result="success",
+            duration_ms=0,
+            project_shape=telemetry.project_shape_from_manifest_path(project_dir / "target"),
+            features_used=("watch",) if watch else (),
+        )
 
     if watch:
         from docglow.server.watcher import start_watcher

--- a/src/docglow/telemetry/config.py
+++ b/src/docglow/telemetry/config.py
@@ -51,8 +51,10 @@ class TelemetryConfig:
     endpoint: str = DEFAULT_ENDPOINT
 
 
-def _parse_tristate(value: str | None) -> bool | None:
-    """Return True/False for an env var, or None when unset/unrecognised."""
+def parse_tristate(value: str | None) -> bool | None:
+    """Return ``True``/``False`` for a truthy/falsy env var value, or ``None``
+    when unset or unrecognised. Public API: re-used by the dispatcher to
+    distinguish "user explicitly opted out" from "default off"."""
     if value is None:
         return None
     normalized = value.strip().lower()
@@ -74,10 +76,10 @@ def resolve_telemetry_config(
     """
     environ = env if env is not None else os.environ
 
-    if _parse_tristate(environ.get(ENV_OPT_OUT)) is True:
+    if parse_tristate(environ.get(ENV_OPT_OUT)) is True:
         return TelemetryConfig(enabled=False, endpoint=_resolve_endpoint(raw, environ))
 
-    env_opt_in = _parse_tristate(environ.get(ENV_OPT_IN))
+    env_opt_in = parse_tristate(environ.get(ENV_OPT_IN))
     if env_opt_in is not None:
         return TelemetryConfig(enabled=env_opt_in, endpoint=_resolve_endpoint(raw, environ))
 

--- a/src/docglow/telemetry/config.py
+++ b/src/docglow/telemetry/config.py
@@ -13,12 +13,22 @@ This precedence is part of the user-facing privacy contract documented in
 
 from __future__ import annotations
 
+import logging
 import os
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_ENDPOINT = "https://api.docglow.com/v1/telemetry/events"
+
+# http:// is permitted only for these hosts (test/dev). Everything else must
+# use https:// so payloads aren't sent over plaintext to a misconfigured or
+# attacker-supplied endpoint. Silent fallback to DEFAULT_ENDPOINT preserves
+# the never-break-CLI invariant.
+_HTTP_ALLOWED_HOSTS = {"localhost", "127.0.0.1", "::1"}
 
 ENV_OPT_IN = "DOCGLOW_TELEMETRY"
 ENV_OPT_OUT = "DOCGLOW_NO_TELEMETRY"
@@ -75,13 +85,46 @@ def resolve_telemetry_config(
     return TelemetryConfig(enabled=yml_enabled, endpoint=_resolve_endpoint(raw, environ))
 
 
+def _is_safe_endpoint(endpoint: str) -> bool:
+    """Return True iff ``endpoint`` is HTTPS, or HTTP to an allowed local host.
+
+    Plaintext HTTP to remote hosts is rejected so a misconfigured yml or env
+    var can't route payloads (and any ``DOCGLOW_VERCEL_BYPASS`` token) over
+    an unencrypted channel.
+    """
+    try:
+        parsed = urlparse(endpoint)
+    except ValueError:
+        return False
+    if parsed.scheme == "https":
+        return bool(parsed.hostname)
+    if parsed.scheme == "http":
+        return parsed.hostname in _HTTP_ALLOWED_HOSTS
+    return False
+
+
 def _resolve_endpoint(raw: dict[str, Any] | None, env: Mapping[str, str]) -> str:
-    """Resolve the endpoint: env override > yml > default."""
+    """Resolve the endpoint: env override > yml > default.
+
+    Rejects non-HTTPS endpoints (except http://localhost) by silently falling
+    back to ``DEFAULT_ENDPOINT``. The user has opted in by configuring an
+    override at all, but we don't honor an override that downgrades transport.
+    """
     override = env.get(ENV_ENDPOINT_OVERRIDE)
     if override:
-        return override
+        if _is_safe_endpoint(override):
+            return override
+        logger.debug(
+            "telemetry: rejecting non-HTTPS endpoint override %r; falling back to default",
+            override,
+        )
     if isinstance(raw, dict):
         endpoint = raw.get("endpoint")
         if isinstance(endpoint, str) and endpoint:
-            return endpoint
+            if _is_safe_endpoint(endpoint):
+                return endpoint
+            logger.debug(
+                "telemetry: rejecting non-HTTPS endpoint from yml %r; falling back to default",
+                endpoint,
+            )
     return DEFAULT_ENDPOINT

--- a/src/docglow/telemetry/dispatcher.py
+++ b/src/docglow/telemetry/dispatcher.py
@@ -1,36 +1,25 @@
 """Telemetry dispatcher: the single integration point used by CLI commands.
 
 Owns the gate logic ("should we send?"), payload assembly, and dispatch. CLI
-commands call ``record_command`` (or use the ``record`` context manager) and
-remain ignorant of every other module in this package.
+commands use the :func:`record` context manager and remain ignorant of every
+other module in this package.
 
-Gate logic, in order:
-
-    1. ``DOCGLOW_NO_TELEMETRY=1`` -- force off (re-checked here defensively
-       even though it is also folded into ``TelemetryConfig.enabled``).
-    2. ``config.enabled`` -- env opt-in or yml flag says yes.
-    3. ``consent == 'yes'`` -- the user accepted the first-run prompt.
-
-Anything that fails any of these returns silently. Failures inside this
-module never raise into the caller.
+Failures inside this module never raise into the caller.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import time
-from collections.abc import Callable, Iterator, Mapping
+from collections.abc import Callable, Iterable, Iterator, Mapping
 from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from docglow.telemetry import client, state
-from docglow.telemetry.config import (
-    ENV_OPT_OUT,
-    TelemetryConfig,
-    _parse_tristate,
-)
+from docglow.telemetry.config import ENV_OPT_OUT, TelemetryConfig, parse_tristate
 from docglow.telemetry.payload import (
     CommandName,
     ProjectShape,
@@ -49,42 +38,68 @@ def is_active(
     consent: state.ConsentValue,
     env: Mapping[str, str] | None = None,
 ) -> bool:
-    """Return True iff telemetry should fire for this run."""
+    """Return True iff telemetry should fire for this run.
+
+    ``DOCGLOW_NO_TELEMETRY`` is re-checked here because ``config.enabled=False``
+    is overloaded between "default off" and "user explicitly opted out", and
+    only the env-var presence distinguishes the two -- consent="yes" should
+    not beat an explicit opt-out.
+    """
     environ = env if env is not None else os.environ
-    if _parse_tristate(environ.get(ENV_OPT_OUT)) is True:
+    if parse_tristate(environ.get(ENV_OPT_OUT)) is True:
         return False
     if config.enabled:
         return True
     return consent == "yes"
 
 
-def project_shape_from_manifest(manifest: Manifest | None) -> ProjectShape:
-    """Build an anonymous ProjectShape from an in-memory dbt Manifest.
+def _shape_from_resource_types(
+    resource_types: Iterable[str],
+    sources: int,
+    macros: int,
+    adapter_raw: object,
+) -> ProjectShape:
+    """Build a ProjectShape from a stream of resource_type strings + counts.
 
-    Returns a zero-shape if the manifest is None or any field access fails.
+    Shared core for both the in-memory Manifest and on-disk manifest.json
+    paths -- both end up doing the same counting and adapter normalisation.
     """
+    models = seeds = tests = 0
+    for rt in resource_types:
+        if rt == "model":
+            models += 1
+        elif rt == "seed":
+            seeds += 1
+        elif rt == "test":
+            tests += 1
+    adapter_type: str | None = None
+    if isinstance(adapter_raw, str) and adapter_raw:
+        adapter_type = adapter_raw.lower()
+    return ProjectShape(
+        models=models,
+        sources=sources,
+        seeds=seeds,
+        tests=tests,
+        macros=macros,
+        adapter_type=adapter_type,
+    )
+
+
+def project_shape_from_manifest(manifest: Manifest | None) -> ProjectShape:
+    """Build an anonymous ProjectShape from an in-memory dbt Manifest."""
     if manifest is None:
         return ProjectShape()
     try:
-        nodes = manifest.nodes.values() if hasattr(manifest, "nodes") else []
-        models = sum(1 for n in nodes if getattr(n, "resource_type", "") == "model")
-        seeds = sum(1 for n in nodes if getattr(n, "resource_type", "") == "seed")
-        tests = sum(1 for n in nodes if getattr(n, "resource_type", "") == "test")
+        nodes = manifest.nodes.values() if hasattr(manifest, "nodes") else ()
         sources = len(manifest.sources) if hasattr(manifest, "sources") and manifest.sources else 0
         macros = len(manifest.macros) if hasattr(manifest, "macros") and manifest.macros else 0
-        adapter_type: str | None = None
         metadata = getattr(manifest, "metadata", None)
-        if metadata is not None:
-            raw = getattr(metadata, "adapter_type", None)
-            if isinstance(raw, str) and raw:
-                adapter_type = raw.lower()
-        return ProjectShape(
-            models=models,
+        adapter_raw = getattr(metadata, "adapter_type", None) if metadata is not None else None
+        return _shape_from_resource_types(
+            (getattr(n, "resource_type", "") for n in nodes),
             sources=sources,
-            seeds=seeds,
-            tests=tests,
             macros=macros,
-            adapter_type=adapter_type,
+            adapter_raw=adapter_raw,
         )
     except Exception as exc:
         logger.debug("telemetry: failed to derive ProjectShape from manifest: %s", exc)
@@ -92,45 +107,30 @@ def project_shape_from_manifest(manifest: Manifest | None) -> ProjectShape:
 
 
 def project_shape_from_manifest_path(target_dir: str | Path) -> ProjectShape:
-    """Lightweight manifest.json reader for telemetry use.
+    """Lightweight ``manifest.json`` reader for telemetry use.
 
-    Reads only the fields we need (node resource_types, source/macro counts,
-    adapter_type) without going through pydantic validation. Used by CLI
-    commands that don't otherwise hold a Manifest object so they can record
-    a meaningful payload without paying for full artifact loading.
-
-    Returns ProjectShape() on any failure -- this must never break the
-    calling command.
+    Reads only the fields we need without going through pydantic validation.
+    Used by commands that don't otherwise hold a Manifest object so they can
+    record a meaningful payload without paying for full artifact loading.
     """
-    import json
-
     try:
         path = Path(target_dir) / "manifest.json"
         with path.open(encoding="utf-8") as f:
-            data = json.load(f)
-    except Exception as exc:
+            data: dict[str, Any] = json.load(f)
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
         logger.debug("telemetry: manifest.json peek failed: %s", exc)
         return ProjectShape()
 
     try:
         nodes = data.get("nodes", {}) or {}
-        models = sum(1 for n in nodes.values() if n.get("resource_type") == "model")
-        seeds = sum(1 for n in nodes.values() if n.get("resource_type") == "seed")
-        tests = sum(1 for n in nodes.values() if n.get("resource_type") == "test")
         sources = len(data.get("sources", {}) or {})
         macros = len(data.get("macros", {}) or {})
-        adapter_type = None
-        metadata = data.get("metadata") or {}
-        raw = metadata.get("adapter_type")
-        if isinstance(raw, str) and raw:
-            adapter_type = raw.lower()
-        return ProjectShape(
-            models=models,
+        adapter_raw = (data.get("metadata") or {}).get("adapter_type")
+        return _shape_from_resource_types(
+            (n.get("resource_type", "") for n in nodes.values()),
             sources=sources,
-            seeds=seeds,
-            tests=tests,
             macros=macros,
-            adapter_type=adapter_type,
+            adapter_raw=adapter_raw,
         )
     except Exception as exc:
         logger.debug("telemetry: manifest.json parse failed: %s", exc)
@@ -143,7 +143,6 @@ def record_command(
     command: CommandName,
     result: ResultName,
     duration_ms: int,
-    manifest: Manifest | None = None,
     project_shape: ProjectShape | None = None,
     features_used: tuple[str, ...] = (),
     consent: state.ConsentValue | None = None,
@@ -151,11 +150,6 @@ def record_command(
     send: bool = True,
 ) -> dict[str, object] | None:
     """Build and dispatch a telemetry event if telemetry is active.
-
-    Pass ``project_shape`` directly when the caller already has it, or
-    ``manifest`` (an in-memory Manifest) for the dispatcher to derive shape.
-    If both are None the payload reports a zero shape -- still valid for
-    commands like ``serve`` that don't necessarily have a manifest at hand.
 
     Returns the payload that was (or would have been) sent, or None when
     telemetry is inactive. Useful for tests; production callers ignore the
@@ -169,14 +163,12 @@ def record_command(
             return None
 
         instance_id = state.get_instance_id(state_path)
-        if project_shape is None:
-            project_shape = project_shape_from_manifest(manifest)
         payload = build_event(
             instance_id=instance_id,
             command=command,
             result=result,
             duration_ms=duration_ms,
-            project_shape=project_shape,
+            project_shape=project_shape or ProjectShape(),
             features_used=features_used,
         )
         if send:
@@ -192,14 +184,14 @@ def record(
     config: TelemetryConfig,
     *,
     command: CommandName,
-    manifest_provider: Callable[[], Manifest | None] | None = None,
+    shape_provider: Callable[[], ProjectShape] | None = None,
     features_used: tuple[str, ...] = (),
 ) -> Iterator[None]:
-    """Context manager that times a command and records success/error on exit.
+    """Time a command and record success/error on exit.
 
-    ``manifest_provider`` is an optional zero-arg callable returning the
-    Manifest (or None). Called inside the ``finally`` block so it picks up
-    a manifest that was loaded mid-command, even on error.
+    ``shape_provider`` is invoked only when telemetry is active, so commands
+    can pass an expensive thunk (e.g. reading manifest.json from disk) without
+    paying for it on the disabled path.
     """
     started = time.monotonic()
     success = False
@@ -209,19 +201,23 @@ def record(
     finally:
         try:
             duration_ms = int((time.monotonic() - started) * 1000)
-            manifest = None
-            if manifest_provider is not None:
+            consent = state.get_consent()
+            if not is_active(config, consent):
+                return
+            shape: ProjectShape | None = None
+            if shape_provider is not None:
                 try:
-                    manifest = manifest_provider()
+                    shape = shape_provider()
                 except Exception:
-                    manifest = None
+                    shape = None
             record_command(
                 config,
                 command=command,
                 result="success" if success else "error",
                 duration_ms=duration_ms,
-                manifest=manifest,
+                project_shape=shape,
                 features_used=features_used,
+                consent=consent,
             )
         except Exception as exc:
             logger.debug("telemetry: record context exit failed: %s", exc)

--- a/src/docglow/telemetry/dispatcher.py
+++ b/src/docglow/telemetry/dispatcher.py
@@ -199,25 +199,27 @@ def record(
         yield
         success = True
     finally:
+        # Never `return` from inside this finally -- doing so swallows any
+        # in-flight exception (including SystemExit) the body raised. Use
+        # nested if/else to gate the work instead.
         try:
             duration_ms = int((time.monotonic() - started) * 1000)
             consent = state.get_consent()
-            if not is_active(config, consent):
-                return
-            shape: ProjectShape | None = None
-            if shape_provider is not None:
-                try:
-                    shape = shape_provider()
-                except Exception:
-                    shape = None
-            record_command(
-                config,
-                command=command,
-                result="success" if success else "error",
-                duration_ms=duration_ms,
-                project_shape=shape,
-                features_used=features_used,
-                consent=consent,
-            )
+            if is_active(config, consent):
+                shape: ProjectShape | None = None
+                if shape_provider is not None:
+                    try:
+                        shape = shape_provider()
+                    except Exception:
+                        shape = None
+                record_command(
+                    config,
+                    command=command,
+                    result="success" if success else "error",
+                    duration_ms=duration_ms,
+                    project_shape=shape,
+                    features_used=features_used,
+                    consent=consent,
+                )
         except Exception as exc:
             logger.debug("telemetry: record context exit failed: %s", exc)

--- a/tests/telemetry/test_config.py
+++ b/tests/telemetry/test_config.py
@@ -95,3 +95,53 @@ def test_default_uses_real_environ_when_env_not_passed(monkeypatch: pytest.Monke
     monkeypatch.setenv(ENV_OPT_IN, "1")
     config = resolve_telemetry_config(None)
     assert config.enabled is True
+
+
+def test_endpoint_rejects_plaintext_http_remote() -> None:
+    config = resolve_telemetry_config(
+        None,
+        env={ENV_ENDPOINT_OVERRIDE: "http://evil.example.com/v1/telemetry/events"},
+    )
+    assert config.endpoint == DEFAULT_ENDPOINT
+
+
+def test_endpoint_allows_http_localhost_for_dev() -> None:
+    config = resolve_telemetry_config(
+        None,
+        env={ENV_ENDPOINT_OVERRIDE: "http://localhost:8080/v1/telemetry/events"},
+    )
+    assert config.endpoint == "http://localhost:8080/v1/telemetry/events"
+
+
+def test_endpoint_allows_http_127_0_0_1_for_dev() -> None:
+    config = resolve_telemetry_config(
+        None,
+        env={ENV_ENDPOINT_OVERRIDE: "http://127.0.0.1:9000/events"},
+    )
+    assert config.endpoint == "http://127.0.0.1:9000/events"
+
+
+def test_endpoint_rejects_yml_plaintext_http_remote() -> None:
+    config = resolve_telemetry_config({"endpoint": "http://evil.example.com/e"}, env={})
+    assert config.endpoint == DEFAULT_ENDPOINT
+
+
+def test_endpoint_rejects_unknown_scheme() -> None:
+    config = resolve_telemetry_config(
+        None,
+        env={ENV_ENDPOINT_OVERRIDE: "ftp://example.com/events"},
+    )
+    assert config.endpoint == DEFAULT_ENDPOINT
+
+
+def test_endpoint_rejects_javascript_scheme() -> None:
+    config = resolve_telemetry_config(
+        None,
+        env={ENV_ENDPOINT_OVERRIDE: "javascript:alert(1)"},
+    )
+    assert config.endpoint == DEFAULT_ENDPOINT
+
+
+def test_endpoint_rejects_https_with_no_host() -> None:
+    config = resolve_telemetry_config(None, env={ENV_ENDPOINT_OVERRIDE: "https:///path"})
+    assert config.endpoint == DEFAULT_ENDPOINT

--- a/tests/test_cli_telemetry_integration.py
+++ b/tests/test_cli_telemetry_integration.py
@@ -10,6 +10,7 @@ from click.testing import CliRunner
 
 from docglow import cloud_hint
 from docglow.cli import cli
+from docglow.telemetry import state as telemetry_state
 from docglow.telemetry.config import TelemetryConfig
 
 
@@ -27,8 +28,8 @@ def _mock_config(telemetry_enabled: bool = False) -> MagicMock:
 
 @pytest.fixture(autouse=True)
 def isolated_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    state = tmp_path / "cloud_hint.json"
-    monkeypatch.setattr(cloud_hint, "_state_path", lambda: state)
+    monkeypatch.setattr(cloud_hint, "_state_path", lambda: tmp_path / "cloud_hint.json")
+    monkeypatch.setattr(telemetry_state, "_state_path", lambda: tmp_path / "telemetry.json")
     monkeypatch.setenv("DOCGLOW_NO_CLOUD_HINT", "1")
     monkeypatch.delenv("CI", raising=False)
     monkeypatch.delenv("DOCGLOW_TELEMETRY", raising=False)
@@ -94,11 +95,11 @@ def test_generate_records_error_when_fail_under_trips(tmp_path: Path) -> None:
     assert mock_record.call_args.kwargs["result"] == "error"
 
 
-def test_generate_dispatcher_still_called_when_telemetry_disabled(tmp_path: Path) -> None:
-    """When disabled, record_command is still invoked but is internally a no-op.
-
-    The gate logic lives inside record_command, not at the call site -- this
-    keeps the command-level wiring trivial and centralises the gate.
+def test_generate_skips_record_command_when_telemetry_disabled(tmp_path: Path) -> None:
+    """When telemetry is inactive, the record() context manager short-circuits
+    before record_command is invoked. This is intentional: the shape_provider
+    (which may do disk I/O like reading manifest.json) is also skipped on the
+    disabled path, saving 50-500 ms per generate run.
     """
     runner = CliRunner()
     with (
@@ -112,7 +113,7 @@ def test_generate_dispatcher_still_called_when_telemetry_disabled(tmp_path: Path
         result = runner.invoke(cli, ["generate", "--project-dir", str(tmp_path)])
 
     assert result.exit_code == 0
-    mock_record.assert_called_once()
+    mock_record.assert_not_called()
 
 
 def test_generate_features_used_reflects_active_flags(tmp_path: Path) -> None:


### PR DESCRIPTION
Two follow-ups to [DOC-196](https://linear.app/docglow/issue/DOC-196) (opt-in telemetry, merged in #98) that landed on the branch after the squash-merge.

## 1. fix(telemetry): reject non-HTTPS endpoint overrides except for localhost

Surfaced by /security-review on the original telemetry branch. A misconfigured `docglow.yml` or `DOCGLOW_TELEMETRY_ENDPOINT` could route opted-in telemetry payloads over plaintext, exposing the (anonymous, but still) event body and any `DOCGLOW_VERCEL_BYPASS` token attached to the request. The cloud `httpx.Client` enforces HTTPS by virtue of its scheme handling; the urllib transport accepted whatever string was configured.

`_resolve_endpoint` now rejects any scheme other than `https://`, except `http://localhost`, `http://127.0.0.1`, and `http://[::1]` for local development. Silent fallback to `DEFAULT_ENDPOINT` preserves the never-break-CLI invariant. Documented in `docs/telemetry.md`.

7 new tests covering: plaintext remote rejected, localhost/127.0.0.1 allowed, yml plaintext rejected, ftp/javascript schemes rejected, https with no host rejected.

## 2. refactor(telemetry): use record() context manager + collapse shape helpers

Surfaced by /simplify review. Three wins:

- `commands/{generate,health}.py` now use `telemetry.record()` instead of re-implementing the started/result/duration/finally boilerplate inline. Removes ~30 lines, drops two `# type: ignore[arg-type]` comments. Side benefit: `record()` only invokes `shape_provider` when telemetry is active, so the manifest peek is skipped on the disabled path. **Saves ~50-500 ms per `generate` run when telemetry is off.**
- `project_shape_from_manifest` and `project_shape_from_manifest_path` were 90% duplicated. Extracted `_shape_from_resource_types` so both feed into the same counting + adapter normalisation. Same external API.
- Promoted `parse_tristate` from a private symbol that the dispatcher was reaching across module boundaries for. The leaky private import was flagged by the quality review; renaming + documenting precedence semantics on `is_active` makes the contract explicit.
- Narrows the manifest-path peek's outer `except` to `(OSError, JSONDecodeError, UnicodeDecodeError)` so genuine bugs propagate while file/encoding failures still no-op as the privacy contract requires.

Net: 5 source files, +161/-183.

## Test plan

- [x] 720 pytest passing (no test count change)
- [x] ruff check + ruff format clean across `src/` + `tests/`
- [x] mypy clean across `src/docglow` (74 files)
- [x] All telemetry tests still pass; HTTPS-only validation has 7 new tests covering the negative cases

## Follow-ups still in backlog (not in this PR)

- [DOC-207](https://linear.app/docglow/issue/DOC-207) — drop bypass header on cross-origin redirects
- [DOC-208](https://linear.app/docglow/issue/DOC-208) — sanitize `adapter_type` and `features_used`
- [DOC-209](https://linear.app/docglow/issue/DOC-209) — write state file with 0600 perms
- [DOC-210](https://linear.app/docglow/issue/DOC-210) — extract shared `state_file.py` + `env.py` helpers