### PR TITLE
feat: enable_erd in docglow.yml + release v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-05-08
+
+### Added
+- **`enable_erd` config field** — the ERD view can now be enabled persistently via `enable_erd: true` in `docglow.yml` (matches what the v0.8.0 changelog promised). The `--enable-erd` CLI flag still works and overrides the yml value.
+
 ## [0.8.0] - 2026-05-08
 
 ### Added

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,6 +19,7 @@ title: "My dbt Project"       # Custom site title
 theme: auto                     # auto | light | dark
 slim: false                     # Omit SQL from output to reduce file size
 column_lineage: true            # Enable column-level lineage (default: true)
+enable_erd: false               # Render the /erd view (default: false). See docs/erd.md
 
 health:
   weights:

--- a/docs/erd.md
+++ b/docs/erd.md
@@ -14,13 +14,20 @@ The ERD is derived directly from declarations you already have in your project â
 
 ## Enable the ERD
 
-The ERD is opt-in. Pass `--enable-erd` when generating the site:
+The ERD is opt-in. Either pass `--enable-erd` on the command line:
 
 ```bash
 docglow generate --enable-erd
 ```
 
-Without the flag, the `/erd` route is hidden and no relationship data is included in the payload.
+â€¦or set it persistently in `docglow.yml` so every generate picks it up (requires v0.8.1+):
+
+```yaml
+# docglow.yml
+enable_erd: true
+```
+
+The CLI flag overrides the yml value. Without either, the `/erd` route is hidden and no relationship data is included in the payload.
 
 ## How relationships are detected
 

--- a/src/docglow/__init__.py
+++ b/src/docglow/__init__.py
@@ -1,3 +1,3 @@
 """docglow: Next-generation dbt documentation site generator."""
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"

--- a/src/docglow/commands/generate.py
+++ b/src/docglow/commands/generate.py
@@ -88,7 +88,7 @@ from docglow.cloud_hint import maybe_show_hint
     "--enable-erd",
     is_flag=True,
     default=False,
-    help="Extract relationship data for the ERD view (DOC-213, opt-in until v0.8)",
+    help="Render the ERD view at /erd. Also settable via enable_erd: true in docglow.yml.",
 )
 def generate(
     project_dir: Path,
@@ -138,6 +138,8 @@ def generate(
         title = config.title
     if not slim and config.slim:
         slim = True
+    if not enable_erd and config.enable_erd:
+        enable_erd = True
 
     # Resolve column lineage: on by default, off via --skip-column-lineage or config
     column_lineage = not skip_column_lineage

--- a/src/docglow/config.py
+++ b/src/docglow/config.py
@@ -114,6 +114,7 @@ class DocglowConfig:
     ui: UiConfig = field(default_factory=UiConfig)
     slim: bool = False
     column_lineage: bool = True
+    enable_erd: bool = False
     lineage_layers: LineageLayerConfig = field(default_factory=LineageLayerConfig)
     telemetry: TelemetryConfig = field(default_factory=TelemetryConfig)
 
@@ -282,6 +283,7 @@ def _build_config_from_dict(raw: dict[str, Any]) -> DocglowConfig:
         theme=raw.get("theme", "auto"),
         slim=raw.get("slim", False),
         column_lineage=raw.get("column_lineage", True),
+        enable_erd=bool(raw.get("enable_erd", False)),
         profiling=profiling,
         health=HealthConfig(weights=weights, naming_rules=naming_rules, complexity=complexity),
         ai=ai,

--- a/tests/test_cli_enable_erd.py
+++ b/tests/test_cli_enable_erd.py
@@ -14,13 +14,14 @@ from click.testing import CliRunner
 from docglow.cli import cli
 
 
-def _make_mock_config() -> MagicMock:
+def _make_mock_config(*, enable_erd: bool = False) -> MagicMock:
     """Mirror the helper used in tests/test_cli_warnings.py."""
     config = MagicMock()
     config.ai.enabled = False
     config.title = "docglow"
     config.slim = False
     config.column_lineage = False
+    config.enable_erd = enable_erd
     return config
 
 
@@ -66,3 +67,43 @@ class TestEnableErdFlag:
         assert mock_gen.called
         kwargs = mock_gen.call_args.kwargs
         assert kwargs.get("enable_erd") is False
+
+    def test_yml_enable_erd_propagates_without_cli_flag(self, tmp_path: Path) -> None:
+        """`enable_erd: true` in docglow.yml should turn the ERD on without the CLI flag."""
+        runner = CliRunner()
+        with (
+            patch(
+                "docglow.config.load_config",
+                return_value=_make_mock_config(enable_erd=True),
+            ),
+            patch("docglow.generator.site.generate_site") as mock_gen,
+        ):
+            mock_gen.return_value = (tmp_path / "out", 100.0)
+            result = runner.invoke(
+                cli,
+                ["generate", "--project-dir", str(tmp_path)],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        assert mock_gen.call_args.kwargs.get("enable_erd") is True
+
+    def test_cli_flag_works_when_yml_disables(self, tmp_path: Path) -> None:
+        """CLI flag enables the ERD even if yml omits / disables it."""
+        runner = CliRunner()
+        with (
+            patch(
+                "docglow.config.load_config",
+                return_value=_make_mock_config(enable_erd=False),
+            ),
+            patch("docglow.generator.site.generate_site") as mock_gen,
+        ):
+            mock_gen.return_value = (tmp_path / "out", 100.0)
+            result = runner.invoke(
+                cli,
+                ["generate", "--project-dir", str(tmp_path), "--enable-erd"],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        assert mock_gen.call_args.kwargs.get("enable_erd") is True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -42,6 +42,20 @@ class TestBuildConfigFromDict:
         config = _build_config_from_dict({})
         assert config.title == "docglow"
         assert config.health.weights == HealthWeights()
+        assert config.enable_erd is False
+
+    def test_enable_erd_true(self):
+        config = _build_config_from_dict({"enable_erd": True})
+        assert config.enable_erd is True
+
+    def test_enable_erd_false_explicit(self):
+        config = _build_config_from_dict({"enable_erd": False})
+        assert config.enable_erd is False
+
+    def test_enable_erd_truthy_coerces(self):
+        # YAML strings like "yes" parse to True; other truthy values should also work.
+        config = _build_config_from_dict({"enable_erd": "yes"})
+        assert config.enable_erd is True
 
     def test_custom_health_weights(self):
         config = _build_config_from_dict(


### PR DESCRIPTION
## Summary

Patches the v0.8.0 CHANGELOG promise — `enable_erd` is now a real field in `docglow.yml`, not just a CLI flag.

### Changes
- `src/docglow/config.py` — adds `enable_erd: bool = False` to `DocglowConfig` and parses it from yml.
- `src/docglow/commands/generate.py` — CLI flag falls back to the yml value when not passed (matches the `slim` precedence pattern). Help text refreshed (the old "opt-in until v0.8" copy was stale post-release).
- `tests/test_config.py` — yml parsing: default false, true, false, truthy coercion (e.g. `"yes"`).
- `tests/test_cli_enable_erd.py` — yml-only enables the ERD; CLI flag still works regardless of yml; helper signature widened to inject the field.
- `src/docglow/__init__.py` — `0.8.0` → `0.8.1`.
- `CHANGELOG.md` — `[0.8.1] - 2026-05-08` entry.

### Precedence
- CLI `--enable-erd` passed → ON (regardless of yml)
- yml `enable_erd: true` → ON
- Neither → OFF (default)

## Test plan
- [x] 815/815 pytest pass locally (810 prior + 5 new)
- [x] ruff + format + mypy clean
- [ ] CI green
- [ ] After merge: tag `v0.8.1`, create release → PyPI publish