### PR TITLE
chore: release v0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.8.2] - 2026-05-19
+
 ### Added
-- **Column lineage extends into source columns declared in `sources.yml`** — projects that document source columns in `sources.yml` but skip `dbt docs generate` now get column-level lineage all the way to source columns. Catalog still wins on `data_type` and ordering when present; `sources.yml`-only columns are appended in declaration order. Column-level tests on sources (e.g. `not_null`, `unique`) also render on the source detail page. (#93)
+- **Column lineage extends into source columns declared in `sources.yml`** — projects that document source columns in `sources.yml` but skip `dbt docs generate` now get column-level lineage all the way to source columns. Catalog still wins on `data_type` and ordering when present; `sources.yml`-only columns are appended in declaration order. Column-level tests on sources (e.g. `not_null`, `unique`) also render on the source detail page. (#93, #107)
 
 ## [0.8.1] - 2026-05-08
 

--- a/src/docglow/__init__.py
+++ b/src/docglow/__init__.py
@@ -1,3 +1,3 @@
 """docglow: Next-generation dbt documentation site generator."""
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"


### PR DESCRIPTION
## Summary
- Bump version to 0.8.2
- Move column-lineage-into-source-columns entry from Unreleased into 0.8.2 section (shipped via #107)

## Test plan
- [ ] CI green (ruff, format, mypy, pytest 3.10-3.13, frontend tests)
- [ ] After merge: tag `v0.8.2` and publish GitHub release → PyPI workflow auto-fires