### PR TITLE
fix(cloud): default API URL to app.docglow.com + add --api-url override

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -127,12 +127,21 @@ docglow publish [OPTIONS]
 | `--token` | `DOCGLOW_TOKEN` env var | API token |
 | `--project-dir` | `.` | Path to the dbt project root |
 | `--target-dir` | `target/` | Path to the dbt target directory |
+| `--api-url` | `https://app.docglow.com` | Override the API base URL. Falls back to `DOCGLOW_API_URL` env var, then `~/.docglow/config.json`. |
 | `--no-wait` | off | Don't wait for processing to complete |
 | `--verbose` | off | Enable debug logging |
 
+To target a non-production environment (e.g. staging):
+
+```bash
+docglow publish --api-url https://app-staging.docglow.com
+# or
+DOCGLOW_API_URL=https://app-staging.docglow.com docglow publish
+```
+
 ### `docglow login`
 
-Authenticate with Docglow Cloud.
+Authenticate with Docglow Cloud. Get your API token at [https://app.docglow.com/settings/tokens](https://app.docglow.com/settings/tokens).
 
 ```bash
 docglow login [--token YOUR_TOKEN]

--- a/src/docglow/cloud/__init__.py
+++ b/src/docglow/cloud/__init__.py
@@ -1,1 +1,1 @@
-"""Cloud integration for docglow.dev hosted service."""
+"""Cloud integration for docglow.com hosted service."""

--- a/src/docglow/cloud/config.py
+++ b/src/docglow/cloud/config.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 CONFIG_DIR = Path.home() / ".docglow"
 CONFIG_FILE = CONFIG_DIR / "config.json"
 
-DEFAULT_API_URL = "https://api.docglow.dev"
+DEFAULT_API_URL = "https://app.docglow.com"
 
 
 @dataclass(frozen=True)

--- a/src/docglow/commands/cloud.py
+++ b/src/docglow/commands/cloud.py
@@ -6,7 +6,7 @@ import click
 @click.command()
 @click.option("--token", type=str, default=None, help="API token for non-interactive auth")
 def login(token: str | None) -> None:
-    """Authenticate with docglow.dev."""
+    """Authenticate with docglow.com."""
     from docglow.cli import console
     from docglow.cloud.auth import store_token
 
@@ -17,12 +17,12 @@ def login(token: str | None) -> None:
 
     console.print("Interactive browser login is not yet available.")
     console.print("Use [bold]docglow login --token YOUR_TOKEN[/bold] instead.")
-    console.print("Get your token at [bold]https://app.docglow.dev/settings/tokens[/bold]")
+    console.print("Get your token at [bold]https://app.docglow.com/settings/tokens[/bold]")
 
 
 @click.command()
 def logout() -> None:
-    """Remove stored docglow.dev credentials."""
+    """Remove stored docglow.com credentials."""
     from docglow.cli import console
     from docglow.cloud.auth import clear_token
 
@@ -32,8 +32,14 @@ def logout() -> None:
 
 @click.command()
 @click.option("--token", envvar="DOCGLOW_TOKEN", default=None)
+@click.option(
+    "--api-url",
+    default=None,
+    help="Override the API base URL (e.g. https://app-staging.docglow.com). "
+    "Takes precedence over DOCGLOW_API_URL and ~/.docglow/config.json.",
+)
 @click.option("--verbose", is_flag=True)
-def status(token: str | None, verbose: bool) -> None:
+def status(token: str | None, api_url: str | None, verbose: bool) -> None:
     """Check docglow Cloud publish status and site health."""
     from docglow.cli import _setup_logging, console
 
@@ -49,11 +55,13 @@ def status(token: str | None, verbose: bool) -> None:
         )
         raise SystemExit(1)
 
+    from dataclasses import replace
+
     config = load_cloud_config()
     if token:
-        from dataclasses import replace
-
         config = replace(config, token=token)
+    if api_url:
+        config = replace(config, api_base_url=api_url)
 
     if not config.token:
         console.print(

--- a/src/docglow/commands/publish.py
+++ b/src/docglow/commands/publish.py
@@ -14,16 +14,23 @@ import click
 )
 @click.option("--project-dir", type=click.Path(exists=True, path_type=Path), default=".")
 @click.option("--target-dir", type=click.Path(path_type=Path), default=None)
+@click.option(
+    "--api-url",
+    default=None,
+    help="Override the API base URL (e.g. https://app-staging.docglow.com). "
+    "Takes precedence over DOCGLOW_API_URL and ~/.docglow/config.json.",
+)
 @click.option("--no-wait", is_flag=True, help="Don't wait for processing to complete")
 @click.option("--verbose", is_flag=True)
 def publish(
     token: str | None,
     project_dir: Path,
     target_dir: Path | None,
+    api_url: str | None,
     no_wait: bool,
     verbose: bool,
 ) -> None:
-    """Publish documentation to docglow.dev."""
+    """Publish documentation to docglow.com."""
     from docglow.cli import _setup_logging, console
 
     _setup_logging(verbose)
@@ -38,11 +45,13 @@ def publish(
         )
         raise SystemExit(1)
 
+    from dataclasses import replace
+
     config = load_cloud_config()
     if token:
-        from dataclasses import replace
-
         config = replace(config, token=token)
+    if api_url:
+        config = replace(config, api_base_url=api_url)
 
     if not config.token:
         console.print(

--- a/tests/test_cloud_config.py
+++ b/tests/test_cloud_config.py
@@ -1,0 +1,107 @@
+"""Tests for Docglow Cloud config + API URL override precedence."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from docglow.cli import cli
+from docglow.cloud import config as cloud_config
+from docglow.cloud.config import DEFAULT_API_URL, load_cloud_config
+
+
+@pytest.fixture(autouse=True)
+def isolated_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect ~/.docglow/config.json to tmp and clear cloud env vars."""
+    config_dir = tmp_path / ".docglow"
+    config_file = config_dir / "config.json"
+    monkeypatch.setattr(cloud_config, "CONFIG_DIR", config_dir)
+    monkeypatch.setattr(cloud_config, "CONFIG_FILE", config_file)
+    monkeypatch.delenv("DOCGLOW_API_URL", raising=False)
+    monkeypatch.delenv("DOCGLOW_TOKEN", raising=False)
+    return config_file
+
+
+def test_default_api_url_points_at_production_app() -> None:
+    """Regression guard: DEFAULT_API_URL must resolve. api.docglow.dev does not."""
+    assert DEFAULT_API_URL == "https://app.docglow.com"
+
+
+def test_load_cloud_config_uses_default_when_unset() -> None:
+    config = load_cloud_config()
+    assert config.api_base_url == "https://app.docglow.com"
+
+
+def test_load_cloud_config_env_var_overrides_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DOCGLOW_API_URL", "https://app-staging.docglow.com")
+    config = load_cloud_config()
+    assert config.api_base_url == "https://app-staging.docglow.com"
+
+
+def test_load_cloud_config_file_overrides_default(isolated_config: Path) -> None:
+    isolated_config.parent.mkdir(parents=True, exist_ok=True)
+    isolated_config.write_text(json.dumps({"api_base_url": "https://app-dev.docglow.com"}))
+    config = load_cloud_config()
+    assert config.api_base_url == "https://app-dev.docglow.com"
+
+
+def test_load_cloud_config_env_var_overrides_file(
+    isolated_config: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    isolated_config.parent.mkdir(parents=True, exist_ok=True)
+    isolated_config.write_text(json.dumps({"api_base_url": "https://app-dev.docglow.com"}))
+    monkeypatch.setenv("DOCGLOW_API_URL", "https://app-staging.docglow.com")
+    config = load_cloud_config()
+    assert config.api_base_url == "https://app-staging.docglow.com"
+
+
+def _runner_invoke_publish(*extra_args: str) -> tuple[object, MagicMock]:
+    """Invoke `docglow publish` with run_publish mocked. Returns (result, mock)."""
+    runner = CliRunner()
+    with runner.isolated_filesystem() as fs:
+        project_dir = Path(fs)
+        (project_dir / "target").mkdir()
+        mock_run = MagicMock(return_value={"status": "complete", "site_url": ""})
+        with patch("docglow.cloud.publish.run_publish", mock_run):
+            result = runner.invoke(
+                cli,
+                [
+                    "publish",
+                    "--token",
+                    "dg_live_test",
+                    "--project-dir",
+                    str(project_dir),
+                    *extra_args,
+                ],
+            )
+        return result, mock_run
+
+
+def test_publish_api_url_flag_overrides_default() -> None:
+    result, mock_run = _runner_invoke_publish("--api-url", "https://app-staging.docglow.com")
+    assert result.exit_code == 0, result.output
+    config = mock_run.call_args.args[0]
+    assert config.api_base_url == "https://app-staging.docglow.com"
+
+
+def test_publish_api_url_flag_overrides_env_var(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DOCGLOW_API_URL", "https://app-dev.docglow.com")
+    result, mock_run = _runner_invoke_publish("--api-url", "https://app-staging.docglow.com")
+    assert result.exit_code == 0, result.output
+    config = mock_run.call_args.args[0]
+    assert config.api_base_url == "https://app-staging.docglow.com"
+
+
+def test_publish_uses_default_when_no_flag_or_env() -> None:
+    result, mock_run = _runner_invoke_publish()
+    assert result.exit_code == 0, result.output
+    config = mock_run.call_args.args[0]
+    assert config.api_base_url == "https://app.docglow.com"


### PR DESCRIPTION
## Summary

The OSS CLI defaulted `api_base_url` to `https://api.docglow.dev` — a domain that doesn't resolve. Every first-time `docglow publish` user without `DOCGLOW_API_URL` set hit:

```
httpx.ConnectError: [Errno -2] Name or service not known
```

The Next.js publish route lives on the web app at `app.docglow.com`; there is no separate API service. Fix the default, add a `--api-url` flag so staging is reachable without env vars, and clean up the other stale `.dev` strings users see.

## Changes

- `DEFAULT_API_URL` → `https://app.docglow.com`
- `--api-url` flag on `docglow publish` and `docglow status` — precedence: flag > `DOCGLOW_API_URL` env > `~/.docglow/config.json` > default
- Replaced remaining user-facing `docglow.dev` strings: the `docglow login` token URL (`https://app.docglow.dev/settings/tokens` → `.com`), command docstrings, and the cloud module docstring
- `docs/reference/cli.md` documents the override flag + env var with a staging example
- `tests/test_cloud_config.py` covers default + full precedence chain (8 tests)

## Test plan

- [x] `pytest tests/test_cloud_config.py` — 8 new tests pass
- [x] Full suite: `pytest` — 836 passed
- [x] `ruff check`, `ruff format --check`, `mypy` on touched files — clean
- [ ] CI green before merge

Closes DOC-180