### PR TITLE
feat: public per-model lineage entrypoint + shared-state serialization

### DIFF
--- a/src/docglow/lineage/analyzer.py
+++ b/src/docglow/lineage/analyzer.py
@@ -223,6 +223,139 @@ def _analyze_single_model(
     )
 
 
+def serialize_shared_state(
+    models: dict[str, dict[str, Any]],
+    sources: dict[str, dict[str, Any]],
+    seeds: dict[str, dict[str, Any]],
+    snapshots: dict[str, dict[str, Any]],
+    dialect: str | None = None,
+    manifest_nodes: dict[str, Any] | None = None,
+    manifest_sources: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build the project-wide shared state once and return it JSON-serializable.
+
+    This is the build-once half of the per-model analysis seam: a coordinator
+    calls it a single time, ships the returned blob to per-model workers, and
+    each worker rehydrates it with :func:`deserialize_shared_state` before
+    calling :func:`analyze_one_model`.
+
+    The ``resolver`` and ``schema`` are built with exactly the same constructor
+    calls as :func:`analyze_column_lineage`, so the per-model path produces
+    identical lineage to the whole-project path.
+
+    The state is intentionally serialized via ``TableResolver.to_dict()`` (plain
+    string dicts) rather than pickle: it is only ``dict[str, str]`` data, so JSON
+    is safe, and a versioned dict shape is far more durable across OSS versions
+    than a pickle of a class instance.
+
+    Args:
+        models: Transformed model data from build_docglow_data.
+        sources: Transformed source data.
+        seeds: Transformed seed data.
+        snapshots: Transformed snapshot data.
+        dialect: SQL dialect for parsing.
+        manifest_nodes: Raw manifest nodes (for relation_name resolution).
+        manifest_sources: Raw manifest sources (for relation_name resolution).
+
+    Returns:
+        A JSON-serializable dict: ``{"resolver": <to_dict>, "schema": <mapping>,
+        "dialect": <dialect>}``.
+    """
+    resolver = TableResolver(
+        models=models,
+        sources=sources,
+        seeds=seeds,
+        snapshots=snapshots,
+        manifest_nodes=manifest_nodes,
+        manifest_sources=manifest_sources,
+    )
+    schema = build_schema_mapping(models, sources)
+    return {
+        "resolver": resolver.to_dict(),
+        "schema": schema,
+        "dialect": dialect,
+    }
+
+
+def deserialize_shared_state(
+    blob: dict[str, Any],
+) -> tuple[TableResolver, dict[str, dict[str, str]], str | None]:
+    """Reconstruct ``(resolver, schema, dialect)`` from a serialized blob.
+
+    Inverse of :func:`serialize_shared_state`. The returned tuple is the
+    ``shared_state`` argument expected by :func:`analyze_one_model`.
+
+    Args:
+        blob: The dict produced by :func:`serialize_shared_state`.
+
+    Returns:
+        A ``(resolver, schema, dialect)`` tuple.
+    """
+    resolver = TableResolver.from_dict(blob["resolver"])
+    schema: dict[str, dict[str, str]] = blob.get("schema", {})
+    dialect: str | None = blob.get("dialect")
+    return resolver, schema, dialect
+
+
+def analyze_one_model(
+    uid: str,
+    model_data: dict[str, Any],
+    shared_state: tuple[TableResolver, dict[str, dict[str, str]], str | None],
+) -> _ModelLineageResult:
+    """Analyze column lineage for a single model given pre-built shared state.
+
+    Public, importable per-model entrypoint that wraps the pure
+    :func:`_analyze_single_model`. A downstream worker can analyze ONE model
+    given the shared state produced by :func:`deserialize_shared_state`, without
+    depending on private OSS internals or the whole-project pool path.
+
+    This function NEVER raises on a malformed/unparseable model.
+    ``_analyze_single_model`` already catches parse exceptions and returns the
+    result with its ``failure`` field populated; this wrapper preserves that
+    contract and adds a top-level guard so that any unexpected escape still
+    becomes a structured per-model failure rather than an exception.
+
+    Caching is intentionally disabled here (``cached_entry=None``): the per-model
+    fan-out path treats every dispatched model as fresh work.
+
+    Args:
+        uid: The model's dbt unique_id.
+        model_data: The transformed model dict (carrying ``compiled_sql`` /
+            ``raw_sql`` / ``columns`` / ``name``).
+        shared_state: The ``(resolver, schema, dialect)`` tuple from
+            :func:`deserialize_shared_state`.
+
+    Returns:
+        A :class:`_ModelLineageResult` carrying ``.lineage`` (the
+        ``{col: [dep_dict]}`` fragment for this uid), ``.failure``,
+        ``.skipped``, and ``.cache_entry``.
+    """
+    resolver, schema, dialect = shared_state
+    try:
+        return _analyze_single_model(
+            uid=uid,
+            data=model_data,
+            schema=schema,
+            resolver=resolver,
+            dialect=dialect,
+            cached_entry=None,
+        )
+    except Exception as e:  # noqa: BLE001
+        # Defensive backstop: _analyze_single_model already converts parse
+        # failures into a result.failure, so this should be unreachable for
+        # SQL-parse errors. Guards against any other unexpected escape so the
+        # caller always gets a structured failure, never a raised exception.
+        logger.debug("Unexpected error analyzing %s: %s", uid, e)
+        return _ModelLineageResult(
+            uid=uid,
+            failure={
+                "model": uid,
+                "name": model_data.get("name", ""),
+                "error": str(e),
+            },
+        )
+
+
 def analyze_column_lineage(
     models: dict[str, dict[str, Any]],
     sources: dict[str, dict[str, Any]],

--- a/src/docglow/lineage/table_resolver.py
+++ b/src/docglow/lineage/table_resolver.py
@@ -85,6 +85,33 @@ class TableResolver:
                     src_ref = f"{source_name}.{name}"
                     self._short.setdefault(src_ref.lower(), uid)
 
+    def to_dict(self) -> dict[str, dict[str, str]]:
+        """Serialize the resolver's internal lookup state to a plain dict.
+
+        The entire resolvable state is three ``dict[str, str]`` maps, so the
+        result is JSON-serializable and can be transported to another process
+        or host and rehydrated with :meth:`from_dict`.
+        """
+        return {
+            "exact": dict(self._exact),
+            "lower": dict(self._lower),
+            "short": dict(self._short),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, dict[str, str]]) -> TableResolver:
+        """Reconstruct a resolver from :meth:`to_dict` output.
+
+        Bypasses ``__init__``'s indexing (there is nothing left to re-index —
+        the three lookup maps *are* the entire state) and produces a resolver
+        whose :meth:`resolve` behaves identically to the original.
+        """
+        instance = cls.__new__(cls)
+        instance._exact = dict(data.get("exact", {}))
+        instance._lower = dict(data.get("lower", {}))
+        instance._short = dict(data.get("short", {}))
+        return instance
+
     def resolve(self, table_reference: str) -> str | None:
         """Resolve a SQL table reference to a dbt unique_id.
 

--- a/tests/lineage/test_analyzer.py
+++ b/tests/lineage/test_analyzer.py
@@ -11,9 +11,44 @@ import pytest
 from docglow.lineage.analyzer import (
     _hash_sql,
     _load_cache,
+    _ModelLineageResult,
     _save_cache,
+    analyze_column_lineage,
+    analyze_one_model,
     compute_column_lineage_subset,
+    deserialize_shared_state,
+    serialize_shared_state,
 )
+from docglow.lineage.column_parser import detect_dialect
+from docglow.lineage.table_resolver import TableResolver
+
+FIXTURES_DIR = Path(__file__).parent.parent / "fixtures"
+
+
+def _load_jaffle_shop_data() -> tuple[
+    dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any], Any, str | None
+]:
+    """Load jaffle-shop fixtures, returning transformed model dicts + manifest + dialect.
+
+    Mirrors the loader used by tests/test_column_lineage_parallel.py so the U1
+    per-model path is exercised against the same fixtures as the whole-project path.
+    """
+    from docglow.artifacts.loader import load_artifacts
+    from docglow.generator.pipeline import (
+        PipelineContext,
+        stage_filter_nodes,
+        stage_transform_nodes,
+        stage_transform_sources,
+    )
+
+    project = FIXTURES_DIR.parent.parent / "examples" / "jaffle-shop"
+    artifacts = load_artifacts(project)
+    ctx = PipelineContext(artifacts=artifacts, column_lineage_enabled=True)
+    stage_transform_nodes(ctx)
+    stage_filter_nodes(ctx)
+    stage_transform_sources(ctx)
+    dialect = detect_dialect(artifacts.manifest.metadata.adapter_type)
+    return ctx.models, ctx.sources, ctx.seeds, ctx.snapshots, artifacts.manifest, dialect
 
 
 @pytest.fixture()
@@ -257,3 +292,253 @@ class TestComputeColumnLineageSubset:
         """Sources referenced in depends_on are included in the subset."""
         result = compute_column_lineage_subset("stg_orders", dag_models, dag_sources, {}, {})
         assert "source.proj.raw.orders" in result
+
+
+# --- U1: per-model entrypoint + shared-state serialization ---
+
+
+def _inline_resolver(
+    models: dict[str, Any],
+    sources: dict[str, Any],
+    seeds: dict[str, Any],
+    snapshots: dict[str, Any],
+    manifest: Any,
+) -> TableResolver:
+    """Build a TableResolver the same way analyze_column_lineage does."""
+    return TableResolver(
+        models=models,
+        sources=sources,
+        seeds=seeds,
+        snapshots=snapshots,
+        manifest_nodes=dict(manifest.nodes),
+        manifest_sources=dict(manifest.sources),
+    )
+
+
+class TestSerializeSharedStateRoundTrip:
+    """serialize -> deserialize must reproduce an identically-resolving resolver."""
+
+    def test_resolver_round_trip_resolves_identically(self) -> None:
+        models, sources, seeds, snapshots, manifest, dialect = _load_jaffle_shop_data()
+        inline = _inline_resolver(models, sources, seeds, snapshots, manifest)
+
+        blob = serialize_shared_state(
+            models=models,
+            sources=sources,
+            seeds=seeds,
+            snapshots=snapshots,
+            dialect=dialect,
+            manifest_nodes=dict(manifest.nodes),
+            manifest_sources=dict(manifest.sources),
+        )
+        resolver, schema, out_dialect = deserialize_shared_state(blob)
+
+        assert out_dialect == dialect
+
+        # Resolve every short ref the inline resolver knows about — identical results.
+        refs_to_check = list(inline._short.keys()) + list(inline._lower.keys())
+        assert refs_to_check, "expected jaffle-shop to populate resolver lookups"
+        for ref in refs_to_check:
+            assert resolver.resolve(ref) == inline.resolve(ref)
+
+    def test_blob_is_json_serializable(self) -> None:
+        models, sources, seeds, snapshots, manifest, dialect = _load_jaffle_shop_data()
+        blob = serialize_shared_state(
+            models=models,
+            sources=sources,
+            seeds=seeds,
+            snapshots=snapshots,
+            dialect=dialect,
+            manifest_nodes=dict(manifest.nodes),
+            manifest_sources=dict(manifest.sources),
+        )
+        import json
+
+        # Round-trips through JSON unchanged (state is only string dicts).
+        assert json.loads(json.dumps(blob)) == blob
+        assert set(blob.keys()) == {"resolver", "schema", "dialect"}
+        assert set(blob["resolver"].keys()) == {"exact", "lower", "short"}
+
+    def test_table_resolver_to_from_dict_unit(self) -> None:
+        models = {"model.proj.users": {"name": "users", "schema": "public", "database": "mydb"}}
+        original = TableResolver(models=models, sources={})
+        rebuilt = TableResolver.from_dict(original.to_dict())
+        for ref in ("public.users", "mydb.public.users", "PUBLIC.USERS", "nope.table"):
+            assert rebuilt.resolve(ref) == original.resolve(ref)
+
+
+class TestAnalyzeOneModel:
+    """The public per-model entrypoint."""
+
+    def test_happy_path_matches_expected_dependencies(self) -> None:
+        models, sources, seeds, snapshots, manifest, dialect = _load_jaffle_shop_data()
+        blob = serialize_shared_state(
+            models=models,
+            sources=sources,
+            seeds=seeds,
+            snapshots=snapshots,
+            dialect=dialect,
+            manifest_nodes=dict(manifest.nodes),
+            manifest_sources=dict(manifest.sources),
+        )
+        shared = deserialize_shared_state(blob)
+
+        # Pick a model that produces resolved lineage in the project-wide path.
+        project = analyze_column_lineage(
+            models=models,
+            sources=sources,
+            seeds=seeds,
+            snapshots=snapshots,
+            dialect=dialect,
+            manifest_nodes=dict(manifest.nodes),
+            manifest_sources=dict(manifest.sources),
+        )
+        uid = next(u for u, frag in project.items() if frag)
+
+        result = analyze_one_model(uid, models[uid], shared)
+        assert isinstance(result, _ModelLineageResult)
+        assert result.uid == uid
+        assert result.lineage  # non-empty fragment
+        # Each dependency carries the resolved triple.
+        for deps in result.lineage.values():
+            for dep in deps:
+                assert set(dep.keys()) >= {
+                    "source_model",
+                    "source_column",
+                    "transformation",
+                }
+
+    def test_parity_with_project_wide_path(self) -> None:
+        """analyze_one_model produces identical lineage to analyze_column_lineage."""
+        models, sources, seeds, snapshots, manifest, dialect = _load_jaffle_shop_data()
+        blob = serialize_shared_state(
+            models=models,
+            sources=sources,
+            seeds=seeds,
+            snapshots=snapshots,
+            dialect=dialect,
+            manifest_nodes=dict(manifest.nodes),
+            manifest_sources=dict(manifest.sources),
+        )
+        shared = deserialize_shared_state(blob)
+
+        project = analyze_column_lineage(
+            models=models,
+            sources=sources,
+            seeds=seeds,
+            snapshots=snapshots,
+            dialect=dialect,
+            manifest_nodes=dict(manifest.nodes),
+            manifest_sources=dict(manifest.sources),
+            max_workers=1,
+        )
+
+        # Compare the fragment for every model that the project path produced.
+        all_models = {**models, **seeds, **snapshots}
+        checked = 0
+        for uid, expected_fragment in project.items():
+            result = analyze_one_model(uid, all_models[uid], shared)
+            assert result.lineage == expected_fragment, f"fragment mismatch for {uid}"
+            checked += 1
+        assert checked > 0, "expected at least one model with lineage to compare"
+
+    def test_select_star_with_schema_expands(self) -> None:
+        """SELECT * with schema present expands to the upstream columns."""
+        models = {
+            "model.proj.stg": {
+                "name": "stg",
+                "schema": "public",
+                "database": "db",
+                "compiled_sql": "SELECT id, email FROM db.public.raw_users",
+                "columns": [{"name": "id"}, {"name": "email"}],
+            },
+            "model.proj.dwn": {
+                "name": "dwn",
+                "schema": "public",
+                "database": "db",
+                "compiled_sql": "SELECT * FROM db.public.stg",
+                "columns": [{"name": "id"}, {"name": "email"}],
+            },
+        }
+        sources = {
+            "source.proj.raw.raw_users": {
+                "name": "raw_users",
+                "source_name": "raw",
+                "schema": "public",
+                "database": "db",
+                "columns": [{"name": "id"}, {"name": "email"}],
+            }
+        }
+        blob = serialize_shared_state(
+            models=models, sources=sources, seeds={}, snapshots={}, dialect="postgres"
+        )
+        shared = deserialize_shared_state(blob)
+
+        result = analyze_one_model("model.proj.dwn", models["model.proj.dwn"], shared)
+        # SELECT * expanded against the schema → both columns traced to stg.
+        assert set(result.lineage.keys()) == {"id", "email"}
+        for col, deps in result.lineage.items():
+            assert deps[0]["source_model"] == "model.proj.stg"
+
+    def test_select_star_empty_schema_no_crash(self) -> None:
+        """SELECT * with empty schema falls back leniently — no crash."""
+        models = {
+            "model.proj.dwn": {
+                "name": "dwn",
+                "schema": "public",
+                "database": "db",
+                "compiled_sql": "SELECT * FROM db.public.stg",
+                "columns": [{"name": "id"}],
+            }
+        }
+        # Empty schema mapping → SELECT * cannot expand.
+        shared = (TableResolver(models=models, sources={}), {}, "postgres")
+        result = analyze_one_model("model.proj.dwn", models["model.proj.dwn"], shared)
+        assert isinstance(result, _ModelLineageResult)
+        # No exception; fragment may be empty since columns can't be expanded.
+
+    def test_no_edges_returns_empty_fragment(self) -> None:
+        """A model whose deps trace to nothing returns an empty .lineage, not a raise."""
+        models = {
+            "model.proj.lit": {
+                "name": "lit",
+                "schema": "public",
+                "database": "db",
+                # Literal columns reference no upstream table → nothing resolvable.
+                "compiled_sql": "SELECT 1 AS a, 'x' AS b",
+                "columns": [{"name": "a"}, {"name": "b"}],
+            }
+        }
+        blob = serialize_shared_state(
+            models=models, sources={}, seeds={}, snapshots={}, dialect="postgres"
+        )
+        shared = deserialize_shared_state(blob)
+        result = analyze_one_model("model.proj.lit", models["model.proj.lit"], shared)
+        assert result.lineage == {}
+
+    def test_malformed_sql_returns_structured_failure(self) -> None:
+        """Unparseable SQL → structured per-model failure, never a raised exception."""
+        models = {
+            "model.proj.broken": {
+                "name": "broken",
+                "schema": "public",
+                "database": "db",
+                "compiled_sql": "SELECT FROM WHERE ((( not valid sql at all",
+                "columns": [{"name": "x"}],
+            }
+        }
+        blob = serialize_shared_state(
+            models=models, sources={}, seeds={}, snapshots={}, dialect="postgres"
+        )
+        shared = deserialize_shared_state(blob)
+        # Must not raise.
+        result = analyze_one_model("model.proj.broken", models["model.proj.broken"], shared)
+        assert isinstance(result, _ModelLineageResult)
+        assert result.failure is not None
+        assert result.failure["model"] == "model.proj.broken"
+        assert result.lineage == {}
+
+    def test_skips_model_without_sql(self) -> None:
+        shared = (TableResolver(models={}, sources={}), {}, None)
+        result = analyze_one_model("model.proj.empty", {"name": "empty"}, shared)
+        assert result.skipped


### PR DESCRIPTION
## What

Adds a public, importable per-model column-lineage entrypoint plus serializable shared-state helpers, wrapping the existing pure `_analyze_single_model`.

- `analyze_one_model(uid, model_data, shared_state) -> _ModelLineageResult` — analyze one model given pre-built shared state; never raises (preserves the catch-and-return-`.failure` contract + a top-level guard).
- `serialize_shared_state(...) -> dict` / `deserialize_shared_state(blob) -> (resolver, schema, dialect)` — build the project-wide resolver+schema once and ship it JSON-serializable (uses the same constructor calls as `analyze_column_lineage`).
- `TableResolver.to_dict()` / `from_dict()` — round-trip the resolver's three string-dict maps.

## Why

Enables the Docglow Cloud column-lineage parser to fan out **one model per worker** (Modal `.map`) instead of running the whole project in one process, with per-model shared state loaded once per container. The worker needs a clean public per-model API rather than reaching into private `_`-prefixed internals across the vendor boundary.

## Compatibility

**Purely additive — `analyze_column_lineage` is unchanged.** OSS CLI users (`docglow generate`, local lineage) see zero behavior change. +445 lines, 0 deletions.

## Tests

10 new tests in `tests/lineage/test_analyzer.py`: full parity vs the whole-project path, resolver round-trip + JSON-serializability, SELECT * expansion (with/without schema), no-edges → empty fragment, malformed SQL → structured `.failure` (no raise). OSS lineage suite: 100 passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)