### PR TITLE
feat(cloud): ship docglow.yml in publish tarball for author layer/ERD fidelity (DOC-240)

### DIFF
--- a/src/docglow/cloud/publish.py
+++ b/src/docglow/cloud/publish.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from docglow.cloud.client import CloudApiError, CloudClient
 from docglow.cloud.config import CloudConfig
+from docglow.config import CONFIG_FILENAMES
 
 logger = logging.getLogger(__name__)
 
@@ -21,11 +22,6 @@ ARTIFACT_FILES = [
     "sources.json",
     "profiles.json",
 ]
-
-# Author config shipped from the project root (not target/) so Cloud renders the
-# project's own layer rules + ERD preference instead of OSS defaults. First match
-# wins; absent is fine (Cloud falls back to defaults).
-CONFIG_FILES = ["docglow.yml", "docglow.yaml"]
 
 
 def run_publish(
@@ -111,8 +107,13 @@ def _find_artifacts(target_dir: Path) -> list[Path]:
 
 
 def _find_config_file(project_dir: Path) -> Path | None:
-    """Return the project's docglow config file (root), or None if absent."""
-    for name in CONFIG_FILES:
+    """Return the project's docglow config file (root), or None if absent.
+
+    Shipped from the project root (not target/) so Cloud renders the project's
+    own layer rules + ERD preference instead of OSS defaults. First match wins;
+    absence is fine (Cloud falls back to defaults).
+    """
+    for name in CONFIG_FILENAMES:
         path = project_dir / name
         if path.exists():
             return path

--- a/src/docglow/cloud/publish.py
+++ b/src/docglow/cloud/publish.py
@@ -22,6 +22,11 @@ ARTIFACT_FILES = [
     "profiles.json",
 ]
 
+# Author config shipped from the project root (not target/) so Cloud renders the
+# project's own layer rules + ERD preference instead of OSS defaults. First match
+# wins; absent is fine (Cloud falls back to defaults).
+CONFIG_FILES = ["docglow.yml", "docglow.yaml"]
+
 
 def run_publish(
     config: CloudConfig,
@@ -63,8 +68,14 @@ def run_publish(
 
     logger.info("Found %d artifact files", len(found_artifacts))
 
+    # Ship the author's docglow.yml (from the project root) alongside the dbt
+    # artifacts so Cloud renders custom layer rules + ERD preference. Optional —
+    # absence just means Cloud uses defaults.
+    config_file = _find_config_file(project_dir)
+    bundle = found_artifacts + ([config_file] if config_file else [])
+
     # Create tarball
-    tarball_path = _create_tarball(found_artifacts)
+    tarball_path = _create_tarball(bundle)
 
     try:
         client = CloudClient(config)
@@ -97,6 +108,15 @@ def _find_artifacts(target_dir: Path) -> list[Path]:
         if path.exists():
             found.append(path)
     return found
+
+
+def _find_config_file(project_dir: Path) -> Path | None:
+    """Return the project's docglow config file (root), or None if absent."""
+    for name in CONFIG_FILES:
+        path = project_dir / name
+        if path.exists():
+            return path
+    return None
 
 
 def _create_tarball(artifacts: list[Path]) -> Path:

--- a/src/docglow/config.py
+++ b/src/docglow/config.py
@@ -13,6 +13,11 @@ from docglow.telemetry.config import TelemetryConfig, resolve_telemetry_config
 
 logger = logging.getLogger(__name__)
 
+# Config filenames, in precedence order (first match wins). Single source of
+# truth for discovery — used by load_config, `docglow init`, and the Cloud
+# publish bundler.
+CONFIG_FILENAMES = ("docglow.yml", "docglow.yaml")
+
 
 @dataclass(frozen=True)
 class ProfilingConfig:
@@ -129,7 +134,7 @@ def load_config(project_dir: Path) -> DocglowConfig:
 
     Falls back to default config if no file is found.
     """
-    for name in ("docglow.yml", "docglow.yaml"):
+    for name in CONFIG_FILENAMES:
         config_path = project_dir / name
         if config_path.exists():
             logger.info("Loading config from %s", config_path)

--- a/tests/test_cloud_publish.py
+++ b/tests/test_cloud_publish.py
@@ -1,0 +1,46 @@
+"""Tests for the publish tarball bundling — specifically that the author's
+``docglow.yml`` is shipped to Cloud so custom layer rules + ERD preference
+render instead of OSS defaults (DOC-240 / U9 CLI transport)."""
+
+from __future__ import annotations
+
+import tarfile
+from pathlib import Path
+
+from docglow.cloud.publish import _create_tarball, _find_config_file
+
+
+def _write(path: Path, text: str = "x") -> Path:
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_find_config_file_prefers_yml(tmp_path: Path) -> None:
+    _write(tmp_path / "docglow.yml")
+    _write(tmp_path / "docglow.yaml")
+    assert _find_config_file(tmp_path) == tmp_path / "docglow.yml"
+
+
+def test_find_config_file_falls_back_to_yaml(tmp_path: Path) -> None:
+    _write(tmp_path / "docglow.yaml")
+    assert _find_config_file(tmp_path) == tmp_path / "docglow.yaml"
+
+
+def test_find_config_file_absent_returns_none(tmp_path: Path) -> None:
+    assert _find_config_file(tmp_path) is None
+
+
+def test_create_tarball_places_config_at_root(tmp_path: Path) -> None:
+    """The config must land at the tarball root (arcname == filename) because
+    Cloud's coordinator extracts flat and reads ``docglow.yml`` from the root."""
+    manifest = _write(tmp_path / "manifest.json", "{}")
+    config = _write(tmp_path / "docglow.yml", "enable_erd: false\n")
+
+    tarball = _create_tarball([manifest, config])
+    try:
+        with tarfile.open(tarball, "r:gz") as tar:
+            names = tar.getnames()
+        assert "docglow.yml" in names  # root, not nested under a dir
+        assert "manifest.json" in names
+    finally:
+        tarball.unlink(missing_ok=True)


### PR DESCRIPTION
## What

Ship the project author's `docglow.yml` to Docglow Cloud as part of `docglow publish` (DOC-240 / U9 CLI transport).

## Problem

The publish command bundled only the dbt JSON artifacts (`manifest.json`, `catalog.json`, …). The Cloud coordinator builds the hosted site's `docglow-data.json` and already prefers `load_config(extracted_dir)` for layer rules + ERD preference — but the file was never in the tarball, so Cloud always fell back to OSS defaults (default swim-lanes, ERD forced on). Author-controlled layers and the per-project ERD toggle were silently ignored.

## Change (`src/docglow/cloud/publish.py`)

Bundle `docglow.yml` / `docglow.yaml` from the **project root** (not `target/`, where the dbt artifacts live) into the publish tarball. `arcname` is the bare filename, so it extracts at the tarball root — exactly where the Cloud coordinator's `load_config` looks. First match wins (`.yml` over `.yaml`); absent config is fine and keeps today's default behavior.

## Why it's safe / forward-compatible

The Cloud read side already consumes the file. Older Cloud deploys ignore the extra tarball entry. Newer Cloud deploys light up the author's config automatically. Nothing breaks if the file is absent or malformed (Cloud falls back to defaults).

## Tests

New `tests/test_cloud_publish.py` (4 tests): `.yml`-over-`.yaml` precedence, `.yaml` fallback, absent → `None`, and that the config lands at the tarball **root** (the contract that lets Cloud's flat extract find it). `ruff` clean.

## Test plan

- [ ] CI green
- [ ] `docglow publish` from a project with a `docglow.yml` → tarball contains it at the root
- [ ] Publish from a project without one → unchanged (no config entry, no error)
