### PR TITLE
fix(artifacts): tolerate null fields in exposures and catalog stats (DOC-279)

### DIFF
--- a/src/docglow/artifacts/catalog.py
+++ b/src/docglow/artifacts/catalog.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class CatalogMetadata(BaseModel):
@@ -26,6 +26,17 @@ class CatalogStat(BaseModel):
     value: object = None
     include: bool = False
     description: str = ""
+
+    @model_validator(mode="before")
+    @classmethod
+    def _drop_null_fields(cls, data: object) -> object:
+        # Adapters (e.g. Databricks) emit null for stat fields they don't
+        # populate — dbt itself types description as optional, and nulls show
+        # up in label/include too. Strip them so the field defaults apply
+        # instead of failing validation.
+        if isinstance(data, dict):
+            return {k: v for k, v in data.items() if v is not None}
+        return data
 
 
 class CatalogNodeMetadata(BaseModel):

--- a/src/docglow/artifacts/manifest.py
+++ b/src/docglow/artifacts/manifest.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class ManifestMetadata(BaseModel):
@@ -135,6 +135,15 @@ class ManifestExposure(BaseModel):
     owner: dict[str, str] = Field(default_factory=dict)
     tags: list[str] = Field(default_factory=list)
     meta: dict[str, object] = Field(default_factory=dict)
+
+    @field_validator("owner", mode="before")
+    @classmethod
+    def _drop_null_owner_fields(cls, value: object) -> object:
+        # dbt serializes omitted owner fields as null (owner.name and
+        # owner.email are both optional), so strip them before validation.
+        if isinstance(value, dict):
+            return {k: v for k, v in value.items() if v is not None}
+        return value
 
 
 class ManifestMetric(BaseModel):

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -6,8 +6,45 @@ from pathlib import Path
 import pytest
 
 from docglow.artifacts.loader import ArtifactLoadError, LoadedArtifacts, load_artifacts
+from docglow.artifacts.manifest import ManifestExposure
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+class TestManifestExposureOwner:
+    """Exposure owner fields are optional in dbt; nulls must not break parsing."""
+
+    def test_owner_name_null(self) -> None:
+        """dbt writes owner.name as null when only email is set."""
+        exposure = ManifestExposure(
+            unique_id="exposure.jaffle_shop.dashboard",
+            name="dashboard",
+            owner={"name": None, "email": "data@example.com"},
+        )
+        assert exposure.owner == {"email": "data@example.com"}
+
+    def test_owner_email_null(self) -> None:
+        exposure = ManifestExposure(
+            unique_id="exposure.jaffle_shop.dashboard",
+            name="dashboard",
+            owner={"name": "Data Team", "email": None},
+        )
+        assert exposure.owner == {"name": "Data Team"}
+
+    def test_owner_all_null(self) -> None:
+        exposure = ManifestExposure(
+            unique_id="exposure.jaffle_shop.dashboard",
+            name="dashboard",
+            owner={"name": None, "email": None},
+        )
+        assert exposure.owner == {}
+
+    def test_owner_missing(self) -> None:
+        exposure = ManifestExposure(
+            unique_id="exposure.jaffle_shop.dashboard",
+            name="dashboard",
+        )
+        assert exposure.owner == {}
 
 
 class TestLoadArtifacts:

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -5,10 +5,66 @@ from pathlib import Path
 
 import pytest
 
+from docglow.artifacts.catalog import CatalogNode, CatalogStat
 from docglow.artifacts.loader import ArtifactLoadError, LoadedArtifacts, load_artifacts
 from docglow.artifacts.manifest import ManifestExposure
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+class TestCatalogStatNulls:
+    """Adapters like Databricks emit null stat fields; parsing must tolerate them."""
+
+    def test_null_value_and_description(self) -> None:
+        """Databricks reports bytes/rows stats with null value and description."""
+        stat = CatalogStat.model_validate(
+            {"id": "bytes", "label": "Size", "value": None, "include": True, "description": None}
+        )
+        assert stat.value is None
+        assert stat.description == ""
+
+    def test_null_label_and_include(self) -> None:
+        stat = CatalogStat.model_validate(
+            {"id": "rows", "label": None, "value": 42, "include": None, "description": None}
+        )
+        assert stat.label == ""
+        assert stat.include is False
+        assert stat.value == 42
+
+    def test_catalog_node_with_databricks_style_stats(self) -> None:
+        node = CatalogNode.model_validate(
+            {
+                "unique_id": "model.jaffle_shop.orders",
+                "metadata": {"type": "table", "schema": "main", "name": "orders"},
+                "columns": {},
+                "stats": {
+                    "bytes": {
+                        "id": "bytes",
+                        "label": "bytes",
+                        "value": None,
+                        "include": True,
+                        "description": None,
+                    },
+                    "rows": {
+                        "id": "rows",
+                        "label": "rows",
+                        "value": None,
+                        "include": True,
+                        "description": None,
+                    },
+                    "has_stats": {
+                        "id": "has_stats",
+                        "label": "Has Stats?",
+                        "value": True,
+                        "include": False,
+                        "description": "Indicates whether there are statistics for this table",
+                    },
+                },
+            }
+        )
+        assert node.stats["bytes"].value is None
+        assert node.stats["rows"].value is None
+        assert node.stats["has_stats"].value is True
 
 
 class TestManifestExposureOwner:


### PR DESCRIPTION
## Summary

Two artifact-parsing fixes for fields dbt/adapters legitimately emit as `null` but Docglow typed as required. Either one aborted the entire artifact load with a `ValidationError`.

**Exposure owner** — dbt's exposure `owner` has both `name` and `email` optional and serializes omitted fields as `null` (e.g. `"owner": {"name": null, "email": "data@example.com"}`). `ManifestExposure.owner` was typed `dict[str, str]`, so the `null` failed validation. A `mode="before"` validator now strips null values, keeping the `dict[str, str]` contract for downstream consumers (pipeline exposure payload, frontend `formatOwner`).

**Catalog stats** — Databricks emits `null` for stat fields it doesn't populate: `bytes`/`rows` entries arrive with null `value` and `description`, and virtually no adapter fills `description` for numeric stats (dbt itself types `StatsItem.description` as optional). `CatalogStat`'s `str`/`bool` fields rejected explicit nulls. A `mode="before"` validator now drops null fields so defaults apply. Only `.value` is consumed downstream (`generator/transforms/models.py`) and it already guards against `None`.

Fixes DOC-279.

## Test plan

- [x] New unit tests: exposure owner with null name / null email / all-null / missing; Databricks-style stats with null value, description, label, include; full `CatalogNode` parse
- [x] `pytest` — 856 passed (1 pre-existing local failure in `test_cli_cloud_hint.py`, also fails on main, unrelated)
- [x] `ruff check` / `ruff format --check` / `mypy src/docglow` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)