### PR TITLE
chore(release): 0.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.8.5] - 2026-07-10
+
+### Added
+- **`docglow publish` ships `docglow.yml` in the tarball** — the publish bundle previously contained only dbt JSON artifacts, so Docglow Cloud rendered OSS default layer rules and forced the ERD on, ignoring the project author's config. `docglow.yml`/`docglow.yaml` from the project root is now bundled and read by the Cloud coordinator; projects without a config file still fall back to defaults. (#121)
+
+### Fixed
+- **Null-tolerant artifact parsing for exposure owners and catalog stats** — dbt marks exposure `owner.name`/`owner.email` as optional and serializes omitted fields as `null`, and adapters like Databricks emit `null` for catalog stat fields they don't populate (`bytes`/`rows` values, stat descriptions — which virtually no adapter fills for numeric stats). Docglow's artifact models rejected these explicit nulls, aborting the entire manifest or catalog load with a validation error. Null fields are now stripped before validation so defaults apply. (#132)
+
 ## [0.8.4] - 2026-06-29
 
 ### Added

--- a/src/docglow/__init__.py
+++ b/src/docglow/__init__.py
@@ -1,3 +1,3 @@
 """docglow: Next-generation dbt documentation site generator."""
 
-__version__ = "0.8.4"
+__version__ = "0.8.5"


### PR DESCRIPTION
## Summary

Patch release: version bump to **0.8.5** and changelog for everything merged since 0.8.4.

### Added
- `docglow publish` ships `docglow.yml` in the tarball so Cloud honors author layer rules / ERD config (#121)

### Fixed
- Null-tolerant artifact parsing: optional exposure `owner.name`/`owner.email` and null Databricks catalog stat fields no longer abort manifest/catalog loading (#132)

(#125 — demo-site workflow chore — deliberately omitted from the changelog; deploy-only, no product change.)

## Release steps after merge
- Tag `v0.8.5` (triggers PyPI publish)
- `gh release create v0.8.5`

## Test plan
- [x] `pytest` — 856 passed (1 pre-existing local failure in `test_cli_cloud_hint.py`, also fails on main, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)