### PR TITLE
fix: preserve expression lineage alongside star projections

### DIFF
--- a/src/docglow/lineage/column_parser.py
+++ b/src/docglow/lineage/column_parser.py
@@ -242,11 +242,12 @@ def _rewrite_star_to_columns(
     columns: list[str],
     dialect: str | None,
 ) -> str:
-    """Rewrite the outermost SELECT * to list explicit column names.
+    """Rewrite the outermost SELECT * while preserving explicit expressions.
 
     SQLGlot's lineage() cannot trace columns through SELECT * from a CTE.
     By replacing `SELECT * FROM cte` with `SELECT col1, col2 FROM cte`,
-    lineage() can resolve each column through the CTE definitions.
+    lineage() can resolve each column through the CTE definitions. Any
+    non-star expressions in the SELECT list are retained unchanged.
     """
     import sqlglot
     from sqlglot import exp
@@ -269,8 +270,28 @@ def _rewrite_star_to_columns(
     if not has_star:
         return sql
 
-    # Build new column expressions
-    new_exprs = [exp.Column(this=exp.to_identifier(c)) for c in columns]
+    # Do not add a star-expanded column when an explicit expression already
+    # produces that name (for example, ``SELECT expr AS id, *``).
+    explicit_names = {
+        expression.alias_or_name.lower()
+        for expression in outermost.expressions
+        if not isinstance(expression, exp.Star) and expression.alias_or_name
+    }
+    star_exprs = [
+        exp.Column(this=exp.to_identifier(column))
+        for column in columns
+        if column.lower() not in explicit_names
+    ]
+
+    # Preserve explicit expressions and replace only the Star, at its original
+    # position in the projection list.
+    new_exprs = []
+    for expression in outermost.expressions:
+        if isinstance(expression, exp.Star):
+            new_exprs.extend(star_exprs)
+        else:
+            new_exprs.append(expression)
+
     outermost.set("expressions", new_exprs)
 
     result: str = tree.sql(dialect=dialect)

--- a/tests/lineage/test_column_parser.py
+++ b/tests/lineage/test_column_parser.py
@@ -175,6 +175,35 @@ class TestParseColumnLineage:
             d.source_table == "raw_users" and d.source_column == "id" for d in result["user_id"]
         )
 
+    def test_expression_alongside_star_preserves_lineage(self) -> None:
+        """Explicit expressions must survive expansion of a neighboring star."""
+        sql = """
+        WITH renamed AS (
+            SELECT company, part_num
+            FROM epicor_part
+        )
+        SELECT
+            MD5(company || part_num) AS sk_with_star,
+            *
+        FROM renamed
+        """
+        result = parse_column_lineage(
+            sql,
+            known_columns=["sk_with_star", "company", "part_num"],
+            dialect="trino",
+        )
+
+        assert "sk_with_star" in result
+        assert {
+            (dep.source_table, dep.source_column, dep.transformation)
+            for dep in result["sk_with_star"]
+        } == {
+            ("epicor_part", "company", "derived"),
+            ("epicor_part", "part_num", "derived"),
+        }
+        assert "company" in result
+        assert "part_num" in result
+
     def test_select_star_with_schema_resolves_inner_ctes(self) -> None:
         """Schema mapping should help resolve SELECT * inside CTEs."""
         schema = {


### PR DESCRIPTION
Fixes #144

## Summary

- Preserve explicit SELECT expressions when expanding `*` for lineage tracing
- Avoid duplicating explicitly named output columns
- Add a regression test for expressions alongside star projections

## Testing

- `pytest -q tests/lineage/test_column_parser.py` — 35 passed
- `ruff check src/docglow/lineage/column_parser.py tests/lineage/test_column_parser.py`
- `mypy src/docglow/lineage/column_parser.py`