### PR TITLE
fix: map fabricspark adapter to spark dialect

### DIFF
--- a/src/docglow/generator/data.py
+++ b/src/docglow/generator/data.py
@@ -281,6 +281,7 @@ def _build_column_lineage(
     from docglow.lineage.analyzer import analyze_column_lineage
     from docglow.lineage.column_parser import detect_dialect
 
+    adapter_type = manifest.metadata.adapter_type
     dialect = detect_dialect(manifest.metadata.adapter_type)
 
     subset = None
@@ -302,6 +303,7 @@ def _build_column_lineage(
         seeds=seeds,
         snapshots=snapshots,
         dialect=dialect,
+        adapter_type=adapter_type,
         manifest_nodes=dict(manifest.nodes),
         manifest_sources=dict(manifest.sources),
         cache_path=(

--- a/src/docglow/lineage/analyzer.py
+++ b/src/docglow/lineage/analyzer.py
@@ -97,18 +97,21 @@ def _compute_depth_waves(
 _worker_schema: dict[str, dict[str, str]] = {}
 _worker_resolver: TableResolver | None = None
 _worker_dialect: str | None = None
+_worker_adapter_type: str | None = None
 
 
 def _init_worker(
     schema: dict[str, dict[str, str]],
     resolver: TableResolver,
     dialect: str | None,
+    adapter_type: str | None,
 ) -> None:
     """Initialize shared read-only state in each worker process."""
-    global _worker_schema, _worker_resolver, _worker_dialect  # noqa: PLW0603
+    global _worker_schema, _worker_resolver, _worker_dialect, _worker_adapter_type  # noqa: PLW0603
     _worker_schema = schema
     _worker_resolver = resolver
     _worker_dialect = dialect
+    _worker_adapter_type = adapter_type
 
 
 def _analyze_model_in_worker(
@@ -123,6 +126,7 @@ def _analyze_model_in_worker(
         schema=_worker_schema,
         resolver=_worker_resolver,  # type: ignore[arg-type]
         dialect=_worker_dialect,
+        adapter_type=_worker_adapter_type,
         cached_entry=cached_entry,
     )
 
@@ -133,13 +137,18 @@ def _analyze_single_model(
     schema: dict[str, dict[str, str]],
     resolver: TableResolver,
     dialect: str | None,
-    cached_entry: dict[str, Any] | None,
+    adapter_type: str | None = None,
+    cached_entry: dict[str, Any] | None = None,
 ) -> _ModelLineageResult:
     """Analyze column lineage for a single model. Pure function, no side effects.
 
     All inputs are read-only. Returns a result struct that the caller merges
     into shared state.
     """
+    if cached_entry is None and isinstance(adapter_type, dict):
+        cached_entry = adapter_type
+        adapter_type = None
+
     sql = data.get("compiled_sql", "")
     if not sql:
         raw = data.get("raw_sql", "")
@@ -172,6 +181,7 @@ def _analyze_single_model(
             schema=schema,
             dialect=dialect,
             known_columns=known_columns or None,
+            adapter_type=adapter_type,
         )
     except Exception as e:  # noqa: BLE001
         logger.debug("Failed to parse column lineage for %s: %s", uid, e)
@@ -229,6 +239,7 @@ def serialize_shared_state(
     seeds: dict[str, dict[str, Any]],
     snapshots: dict[str, dict[str, Any]],
     dialect: str | None = None,
+    adapter_type: str | None = None,
     manifest_nodes: dict[str, Any] | None = None,
     manifest_sources: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
@@ -274,12 +285,13 @@ def serialize_shared_state(
         "resolver": resolver.to_dict(),
         "schema": schema,
         "dialect": dialect,
+        "adapter_type": adapter_type,
     }
 
 
 def deserialize_shared_state(
     blob: dict[str, Any],
-) -> tuple[TableResolver, dict[str, dict[str, str]], str | None]:
+) -> tuple[TableResolver, dict[str, dict[str, str]], str | None, str | None]:
     """Reconstruct ``(resolver, schema, dialect)`` from a serialized blob.
 
     Inverse of :func:`serialize_shared_state`. The returned tuple is the
@@ -294,13 +306,14 @@ def deserialize_shared_state(
     resolver = TableResolver.from_dict(blob["resolver"])
     schema: dict[str, dict[str, str]] = blob.get("schema", {})
     dialect: str | None = blob.get("dialect")
-    return resolver, schema, dialect
+    adapter_type: str | None = blob.get("adapter_type")
+    return resolver, schema, dialect, adapter_type
 
 
 def analyze_one_model(
     uid: str,
     model_data: dict[str, Any],
-    shared_state: tuple[TableResolver, dict[str, dict[str, str]], str | None],
+    shared_state: tuple[TableResolver, dict[str, dict[str, str]], str | None, str | None],
 ) -> _ModelLineageResult:
     """Analyze column lineage for a single model given pre-built shared state.
 
@@ -330,7 +343,7 @@ def analyze_one_model(
         ``{col: [dep_dict]}`` fragment for this uid), ``.failure``,
         ``.skipped``, and ``.cache_entry``.
     """
-    resolver, schema, dialect = shared_state
+    resolver, schema, dialect, adapter_type = shared_state
     try:
         return _analyze_single_model(
             uid=uid,
@@ -338,6 +351,7 @@ def analyze_one_model(
             schema=schema,
             resolver=resolver,
             dialect=dialect,
+            adapter_type=adapter_type,
             cached_entry=None,
         )
     except Exception as e:  # noqa: BLE001
@@ -362,6 +376,7 @@ def analyze_column_lineage(
     seeds: dict[str, dict[str, Any]],
     snapshots: dict[str, dict[str, Any]],
     dialect: str | None = None,
+    adapter_type: str | None = None,
     manifest_nodes: dict[str, Any] | None = None,
     manifest_sources: dict[str, Any] | None = None,
     cache_path: Path | None = None,
@@ -406,7 +421,7 @@ def analyze_column_lineage(
     schema = build_schema_mapping(models, sources)
 
     # Load cache if available
-    cache = _load_cache(cache_path, dialect)
+    cache = _load_cache(cache_path, dialect, adapter_type)
     cache_hits = 0
 
     column_lineage: dict[str, dict[str, list[dict[str, str]]]] = {}
@@ -461,7 +476,7 @@ def analyze_column_lineage(
         with ProcessPoolExecutor(
             max_workers=workers,
             initializer=_init_worker,
-            initargs=(schema, resolver, dialect),
+            initargs=(schema, resolver, dialect, adapter_type),
         ) as pool:
             futures = {
                 pool.submit(
@@ -502,6 +517,7 @@ def analyze_column_lineage(
                     schema=schema,
                     resolver=resolver,
                     dialect=dialect,
+                    adapter_type=adapter_type,
                     cached_entry=cache.get(uid),
                 )
                 analyzed_count += 1
@@ -536,7 +552,7 @@ def analyze_column_lineage(
     )
 
     # Save updated cache
-    _save_cache(cache_path, cache, dialect)
+    _save_cache(cache_path, cache, dialect, adapter_type)
 
     # Write failure report if there were issues
     if failure_details:
@@ -744,6 +760,7 @@ _CACHE_VERSION_KEY = "__cache_meta__"
 def _load_cache(
     cache_path: Path | None,
     dialect: str | None,
+    adapter_type: str | None,
 ) -> dict[str, Any]:
     """Load the column lineage cache from disk. Returns empty dict on any error."""
     if not cache_path or not cache_path.exists():
@@ -760,8 +777,12 @@ def _load_cache(
 
     # Invalidate if version or dialect changed
     meta = raw.get(_CACHE_VERSION_KEY, {})
-    if meta.get("docglow_version") != __version__ or meta.get("dialect") != dialect:
-        logger.debug("Column lineage cache invalidated (version/dialect change)")
+    if (
+        meta.get("docglow_version") != __version__
+        or meta.get("dialect") != dialect
+        or meta.get("adapter_type") != adapter_type
+    ):
+        logger.debug("Column lineage cache invalidated (version/dialect/adapter change)")
         return {}
 
     # Remove meta key and migrate legacy "direct" → "passthrough"
@@ -795,6 +816,7 @@ def _save_cache(
     cache_path: Path | None,
     cache: dict[str, Any],
     dialect: str | None,
+    adapter_type: str | None,
 ) -> None:
     """Save the column lineage cache to disk."""
     if not cache_path:
@@ -804,6 +826,7 @@ def _save_cache(
         _CACHE_VERSION_KEY: {
             "docglow_version": __version__,
             "dialect": dialect,
+            "adapter_type": adapter_type,
         },
         **cache,
     }

--- a/src/docglow/lineage/column_parser.py
+++ b/src/docglow/lineage/column_parser.py
@@ -18,6 +18,7 @@ _DIALECT_MAP: dict[str, str] = {
     "duckdb": "duckdb",
     "databricks": "databricks",
     "spark": "spark",
+    "fabricspark": "spark",
     "trino": "trino",
     "clickhouse": "clickhouse",
     "athena": "presto",

--- a/src/docglow/lineage/column_parser.py
+++ b/src/docglow/lineage/column_parser.py
@@ -54,6 +54,7 @@ def parse_column_lineage(
     schema: dict[str, dict[str, str]] | None = None,
     dialect: str | None = None,
     known_columns: list[str] | None = None,
+    adapter_type: str | None = None,
 ) -> dict[str, list[ColumnDependency]]:
     """Parse compiled SQL and extract column-level dependencies.
 
@@ -64,6 +65,8 @@ def parse_column_lineage(
         dialect: SQL dialect for parsing (e.g. "snowflake", "bigquery").
         known_columns: Optional list of known output column names (e.g. from
             catalog). Used as fallback when the outermost SELECT uses *.
+        adapter_type: dbt adapter type used for adapter-specific relation
+            handling that must remain separate from the SQL parser dialect.
 
     Returns:
         Dict mapping output column name -> list of upstream ColumnDependency.
@@ -110,7 +113,7 @@ def parse_column_lineage(
     excluded_cols = _get_excluded_columns(select_stmt)
 
     # Detect if outermost SELECT uses * or * EXCLUDE
-    has_star = any(isinstance(expr, exp.Star) for expr in select_stmt.expressions)
+    has_star = any(_is_star_expression(expr) for expr in select_stmt.expressions)
 
     # If SELECT * (with or without EXCLUDE) and we have known columns, use those
     if has_star and known_columns:
@@ -163,6 +166,7 @@ def parse_column_lineage(
                     trace_sql,
                     resolved_schema,
                     dialect,
+                    adapter_type=adapter_type,
                 )
                 if deps:
                     result[col_name] = deps
@@ -189,6 +193,7 @@ def _trace_column_in_executor(
     sql: str,
     schema: dict[str, dict[str, str]],
     dialect: str | None,
+    adapter_type: str | None = None,
     timeout_seconds: int = 2,
 ) -> list[ColumnDependency]:
     """Trace lineage for a single column using a shared executor for timeout."""
@@ -207,7 +212,7 @@ def _trace_column_in_executor(
                 schema=schema or {},
                 dialect=dialect,
             )
-            deps = _collect_dependencies(node)
+            deps = _collect_dependencies(node, adapter_type=adapter_type)
             if deps:
                 return deps
         except Exception:  # noqa: BLE001
@@ -222,7 +227,7 @@ def _trace_column_in_executor(
                 schema={},
                 dialect=dialect,
             )
-            return _collect_dependencies(node)
+            return _collect_dependencies(node, adapter_type=adapter_type)
         except Exception:  # noqa: BLE001
             return []
 
@@ -267,7 +272,7 @@ def _rewrite_star_to_columns(
         return sql
 
     # Only rewrite if the outermost SELECT contains a Star
-    has_star = any(isinstance(expr, exp.Star) for expr in outermost.expressions)
+    has_star = any(_is_star_expression(expr) for expr in outermost.expressions)
     if not has_star:
         return sql
 
@@ -276,7 +281,7 @@ def _rewrite_star_to_columns(
     explicit_names = {
         expression.alias_or_name.lower()
         for expression in outermost.expressions
-        if not isinstance(expression, exp.Star) and expression.alias_or_name
+        if not _is_star_expression(expression) and expression.alias_or_name
     }
     star_exprs = [
         exp.Column(this=exp.to_identifier(column))
@@ -288,7 +293,7 @@ def _rewrite_star_to_columns(
     # position in the projection list.
     new_exprs = []
     for expression in outermost.expressions:
-        if isinstance(expression, exp.Star):
+        if _is_star_expression(expression):
             new_exprs.extend(star_exprs)
         else:
             new_exprs.append(expression)
@@ -305,12 +310,12 @@ def _extract_output_columns(select: Any) -> list[str]:
 
     columns: list[str] = []
     for expression in select.expressions:
+        if _is_star_expression(expression):
+            continue
         if isinstance(expression, exp.Alias):
             columns.append(expression.alias)
         elif isinstance(expression, exp.Column):
             columns.append(expression.name)
-        elif isinstance(expression, exp.Star):
-            continue
         else:
             alias = expression.alias_or_name
             if alias:
@@ -362,7 +367,7 @@ def _resolve_star_from_cte(
             return []
 
         # Check if the CTE itself uses SELECT *
-        cte_has_star = any(isinstance(e, exp.Star) for e in cte_select.expressions)
+        cte_has_star = any(_is_star_expression(e) for e in cte_select.expressions)
         if cte_has_star:
             # CTE also uses SELECT * — we can't resolve further without schema
             return []
@@ -392,7 +397,10 @@ def _get_excluded_columns(select: Any) -> set[str]:
     return excluded
 
 
-def _collect_dependencies(root_node: Any) -> list[ColumnDependency]:
+def _collect_dependencies(
+    root_node: Any,
+    adapter_type: str | None = None,
+) -> list[ColumnDependency]:
     """Walk a SQLGlot lineage node tree and collect leaf dependencies.
 
     The lineage tree has:
@@ -422,7 +430,7 @@ def _collect_dependencies(root_node: Any) -> list[ColumnDependency]:
         source_column = _extract_column_from_node_name(node_name)
 
         if isinstance(lineage_node.source, exp.Table):
-            source_table = _table_to_string(lineage_node.source)
+            source_table = _table_to_string(lineage_node.source, adapter_type=adapter_type)
 
             # If the leaf is a '*', use the parent's column name instead
             if source_column == "*" and parent_node is not None:
@@ -457,8 +465,29 @@ def _walk_with_parent(node: Any, parent: Any | None, result: list[tuple[Any, Any
         _walk_with_parent(child, node, result)
 
 
-def _table_to_string(table: Any) -> str:
+def _normalize_adapter_type(adapter_type: str | None) -> str:
+    return (adapter_type or "").lower()
+
+
+def _preserve_full_relation_parts(adapter_type: str | None) -> bool:
+    return _normalize_adapter_type(adapter_type) in {"fabric", "fabricspark"}
+
+
+def _is_star_expression(expression: Any) -> bool:
+    from sqlglot import exp
+
+    return isinstance(expression, exp.Star) or (
+        isinstance(expression, exp.Column) and expression.is_star
+    )
+
+
+def _table_to_string(table: Any, adapter_type: str | None = None) -> str:
     """Convert a SQLGlot Table expression to a dotted string."""
+    if _preserve_full_relation_parts(adapter_type):
+        table_parts = getattr(table, "parts", None)
+        if table_parts:
+            return ".".join(part.name for part in table_parts)
+
     parts: list[str] = []
     if table.catalog:
         parts.append(table.catalog)

--- a/tests/lineage/test_analyzer.py
+++ b/tests/lineage/test_analyzer.py
@@ -90,44 +90,51 @@ class TestCacheRoundTrip:
                 },
             },
         }
-        _save_cache(cache_file, cache, "postgres")
-        loaded = _load_cache(cache_file, "postgres")
+        _save_cache(cache_file, cache, "postgres", None)
+        loaded = _load_cache(cache_file, "postgres", None)
         assert loaded["model.test.foo"]["sql_hash"] == "abc123"
         assert len(loaded["model.test.foo"]["lineage"]["col_a"]) == 1
 
     def test_load_missing_file(self, cache_dir: Path) -> None:
-        result = _load_cache(cache_dir / "nonexistent.json", "postgres")
+        result = _load_cache(cache_dir / "nonexistent.json", "postgres", None)
         assert result == {}
 
     def test_load_none_path(self) -> None:
-        result = _load_cache(None, "postgres")
+        result = _load_cache(None, "postgres", None)
         assert result == {}
 
     def test_save_none_path(self) -> None:
         # Should not raise
-        _save_cache(None, {"foo": "bar"}, "postgres")
+        _save_cache(None, {"foo": "bar"}, "postgres", None)
 
     def test_invalid_json(self, cache_file: Path) -> None:
         cache_file.write_text("not json", encoding="utf-8")
-        result = _load_cache(cache_file, "postgres")
+        result = _load_cache(cache_file, "postgres", None)
         assert result == {}
 
 
 class TestCacheInvalidation:
     def test_version_change_invalidates(self, cache_file: Path) -> None:
         cache: dict[str, Any] = {"model.test.foo": {"sql_hash": "abc", "lineage": {}}}
-        _save_cache(cache_file, cache, "postgres")
+        _save_cache(cache_file, cache, "postgres", None)
 
         # Patch version to simulate upgrade
         with patch("docglow.lineage.analyzer.__version__", "99.99.99"):
-            loaded = _load_cache(cache_file, "postgres")
+            loaded = _load_cache(cache_file, "postgres", None)
         assert loaded == {}
 
     def test_dialect_change_invalidates(self, cache_file: Path) -> None:
         cache: dict[str, Any] = {"model.test.foo": {"sql_hash": "abc", "lineage": {}}}
-        _save_cache(cache_file, cache, "postgres")
+        _save_cache(cache_file, cache, "postgres", None)
 
-        loaded = _load_cache(cache_file, "snowflake")
+        loaded = _load_cache(cache_file, "snowflake", None)
+        assert loaded == {}
+
+    def test_adapter_type_change_invalidates(self, cache_file: Path) -> None:
+        cache: dict[str, Any] = {"model.test.foo": {"sql_hash": "abc", "lineage": {}}}
+        _save_cache(cache_file, cache, "spark", "fabricspark")
+
+        loaded = _load_cache(cache_file, "spark", "fabric")
         assert loaded == {}
 
     def test_direct_migrated_to_passthrough(self, cache_file: Path) -> None:
@@ -153,8 +160,8 @@ class TestCacheInvalidation:
                 },
             },
         }
-        _save_cache(cache_file, cache, "postgres")
-        loaded = _load_cache(cache_file, "postgres")
+        _save_cache(cache_file, cache, "postgres", None)
+        loaded = _load_cache(cache_file, "postgres", None)
         deps_x = loaded["model.test.bar"]["lineage"]["col_x"]
         deps_y = loaded["model.test.bar"]["lineage"]["col_y"]
         assert deps_x[0]["transformation"] == "passthrough"
@@ -162,9 +169,9 @@ class TestCacheInvalidation:
 
     def test_same_version_and_dialect_preserves(self, cache_file: Path) -> None:
         cache: dict[str, Any] = {"model.test.foo": {"sql_hash": "abc", "lineage": {}}}
-        _save_cache(cache_file, cache, "duckdb")
+        _save_cache(cache_file, cache, "duckdb", None)
 
-        loaded = _load_cache(cache_file, "duckdb")
+        loaded = _load_cache(cache_file, "duckdb", None)
         assert "model.test.foo" in loaded
 
 
@@ -328,12 +335,14 @@ class TestSerializeSharedStateRoundTrip:
             seeds=seeds,
             snapshots=snapshots,
             dialect=dialect,
+            adapter_type=manifest.metadata.adapter_type,
             manifest_nodes=dict(manifest.nodes),
             manifest_sources=dict(manifest.sources),
         )
-        resolver, schema, out_dialect = deserialize_shared_state(blob)
+        resolver, schema, out_dialect, out_adapter_type = deserialize_shared_state(blob)
 
         assert out_dialect == dialect
+        assert out_adapter_type == manifest.metadata.adapter_type
 
         # Resolve every short ref the inline resolver knows about — identical results.
         refs_to_check = list(inline._short.keys()) + list(inline._lower.keys())
@@ -349,6 +358,7 @@ class TestSerializeSharedStateRoundTrip:
             seeds=seeds,
             snapshots=snapshots,
             dialect=dialect,
+            adapter_type=manifest.metadata.adapter_type,
             manifest_nodes=dict(manifest.nodes),
             manifest_sources=dict(manifest.sources),
         )
@@ -356,7 +366,7 @@ class TestSerializeSharedStateRoundTrip:
 
         # Round-trips through JSON unchanged (state is only string dicts).
         assert json.loads(json.dumps(blob)) == blob
-        assert set(blob.keys()) == {"resolver", "schema", "dialect"}
+        assert set(blob.keys()) == {"resolver", "schema", "dialect", "adapter_type"}
         assert set(blob["resolver"].keys()) == {"exact", "lower", "short"}
 
     def test_table_resolver_to_from_dict_unit(self) -> None:
@@ -378,6 +388,7 @@ class TestAnalyzeOneModel:
             seeds=seeds,
             snapshots=snapshots,
             dialect=dialect,
+            adapter_type=manifest.metadata.adapter_type,
             manifest_nodes=dict(manifest.nodes),
             manifest_sources=dict(manifest.sources),
         )
@@ -390,6 +401,7 @@ class TestAnalyzeOneModel:
             seeds=seeds,
             snapshots=snapshots,
             dialect=dialect,
+            adapter_type=manifest.metadata.adapter_type,
             manifest_nodes=dict(manifest.nodes),
             manifest_sources=dict(manifest.sources),
         )
@@ -470,7 +482,12 @@ class TestAnalyzeOneModel:
             }
         }
         blob = serialize_shared_state(
-            models=models, sources=sources, seeds={}, snapshots={}, dialect="postgres"
+            models=models,
+            sources=sources,
+            seeds={},
+            snapshots={},
+            dialect="postgres",
+            adapter_type="postgres",
         )
         shared = deserialize_shared_state(blob)
 
@@ -492,7 +509,7 @@ class TestAnalyzeOneModel:
             }
         }
         # Empty schema mapping → SELECT * cannot expand.
-        shared = (TableResolver(models=models, sources={}), {}, "postgres")
+        shared = (TableResolver(models=models, sources={}), {}, "postgres", "postgres")
         result = analyze_one_model("model.proj.dwn", models["model.proj.dwn"], shared)
         assert isinstance(result, _ModelLineageResult)
         # No exception; fragment may be empty since columns can't be expanded.
@@ -510,7 +527,12 @@ class TestAnalyzeOneModel:
             }
         }
         blob = serialize_shared_state(
-            models=models, sources={}, seeds={}, snapshots={}, dialect="postgres"
+            models=models,
+            sources={},
+            seeds={},
+            snapshots={},
+            dialect="postgres",
+            adapter_type="postgres",
         )
         shared = deserialize_shared_state(blob)
         result = analyze_one_model("model.proj.lit", models["model.proj.lit"], shared)
@@ -528,7 +550,12 @@ class TestAnalyzeOneModel:
             }
         }
         blob = serialize_shared_state(
-            models=models, sources={}, seeds={}, snapshots={}, dialect="postgres"
+            models=models,
+            sources={},
+            seeds={},
+            snapshots={},
+            dialect="postgres",
+            adapter_type="postgres",
         )
         shared = deserialize_shared_state(blob)
         # Must not raise.
@@ -539,6 +566,39 @@ class TestAnalyzeOneModel:
         assert result.lineage == {}
 
     def test_skips_model_without_sql(self) -> None:
-        shared = (TableResolver(models={}, sources={}), {}, None)
+        shared = (TableResolver(models={}, sources={}), {}, None, None)
         result = analyze_one_model("model.proj.empty", {"name": "empty"}, shared)
         assert result.skipped
+
+    def test_analyze_column_lineage_preserves_fabric_relations(self) -> None:
+        models = {
+            "model.proj.source_table": {
+                "name": "source_table",
+                "schema": "dbo",
+                "database": "warehouse_name",
+                "columns": [{"name": "source_id"}],
+            },
+            "model.proj.downstream": {
+                "name": "downstream",
+                "schema": "dbo",
+                "database": "warehouse_name",
+                "compiled_sql": (
+                    "SELECT source_id AS id "
+                    "FROM [server_name].[warehouse_name].[dbo].[source_table]"
+                ),
+                "columns": [{"name": "id"}],
+                "depends_on": [],
+            },
+        }
+
+        result = analyze_column_lineage(
+            models=models,
+            sources={},
+            seeds={},
+            snapshots={},
+            dialect="tsql",
+            adapter_type="fabric",
+            max_workers=1,
+        )
+
+        assert result["model.proj.downstream"]["id"][0]["source_model"] == "model.proj.source_table"

--- a/tests/lineage/test_column_parser.py
+++ b/tests/lineage/test_column_parser.py
@@ -23,6 +23,7 @@ class TestDetectDialect:
         assert detect_dialect("redshift") == "redshift"
         assert detect_dialect("duckdb") == "duckdb"
         assert detect_dialect("databricks") == "databricks"
+        assert detect_dialect("fabricspark") == "spark"
         assert detect_dialect("athena") == "presto"
         assert detect_dialect("sqlserver") == "tsql"
         assert detect_dialect("fabric") == "tsql"

--- a/tests/lineage/test_column_parser.py
+++ b/tests/lineage/test_column_parser.py
@@ -6,6 +6,7 @@ import pytest
 
 from docglow.lineage.column_parser import (
     ColumnDependency,
+    _table_to_string,
     build_schema_mapping,
     detect_dialect,
     parse_column_lineage,
@@ -148,6 +149,31 @@ class TestParseColumnLineage:
         # With schema provided, * should be expanded
         # At minimum we should get no errors
         assert isinstance(result, dict)
+
+    def test_qualified_star_with_known_columns(self) -> None:
+        sql = "SELECT base.* FROM base"
+        result = parse_column_lineage(sql, known_columns=["id", "name"])
+        assert set(result.keys()) == {"id", "name"}
+        assert "*" not in result
+
+    def test_qualified_star_with_expression_preserves_outputs(self) -> None:
+        sql = """
+        WITH base AS (
+            SELECT source_id AS id, source_date AS adjustment_date
+            FROM source_table
+        )
+        SELECT base.*, current_timestamp() AS updated_at
+        FROM base
+        """
+        result = parse_column_lineage(
+            sql,
+            known_columns=["id", "adjustment_date", "updated_at"],
+            dialect="spark",
+        )
+        assert "id" in result
+        assert "adjustment_date" in result
+        assert "*" not in result
+        assert all(key != "*" for key in result)
 
     def test_subquery(self) -> None:
         sql = """
@@ -298,6 +324,108 @@ class TestParseColumnLineage:
             assert isinstance(dep, ColumnDependency)
             with pytest.raises(AttributeError):
                 dep.source_column = "other"  # type: ignore[misc]
+
+
+class TestTableToString:
+    @pytest.mark.parametrize(
+        ("adapter_type", "sql", "expected"),
+        [
+            ("fabricspark", "SELECT * FROM schema_name.table_name", "schema_name.table_name"),
+            (
+                "fabricspark",
+                "SELECT * FROM lakehouse_name.schema_name.table_name",
+                "lakehouse_name.schema_name.table_name",
+            ),
+            (
+                "fabricspark",
+                "SELECT * FROM `workspace_name`.`lakehouse_name`.`schema_name`.`table_name`",
+                "workspace_name.lakehouse_name.schema_name.table_name",
+            ),
+            ("fabric", "SELECT * FROM schema_name.table_name", "schema_name.table_name"),
+            (
+                "fabric",
+                "SELECT * FROM warehouse_name.schema_name.table_name",
+                "warehouse_name.schema_name.table_name",
+            ),
+            (
+                "fabric",
+                "SELECT * FROM [server_name].[warehouse_name].[dbo].[orders]",
+                "server_name.warehouse_name.dbo.orders",
+            ),
+        ],
+    )
+    def test_preserves_full_relation_parts_for_fabric_adapters(
+        self,
+        adapter_type: str,
+        sql: str,
+        expected: str,
+    ) -> None:
+        import sqlglot
+        from sqlglot import exp
+
+        dialect = detect_dialect(adapter_type)
+        parsed = sqlglot.parse_one(sql, dialect=dialect)
+        table = parsed.find(exp.Table)
+
+        assert table is not None
+        assert _table_to_string(table, adapter_type=adapter_type) == expected
+
+    @pytest.mark.parametrize(
+        ("adapter_type", "dialect", "sql", "expected"),
+        [
+            (
+                "spark",
+                "spark",
+                "SELECT * FROM catalog_name.schema_name.table_name",
+                "catalog_name.schema_name.table_name",
+            ),
+            (
+                "databricks",
+                "databricks",
+                "SELECT * FROM catalog_name.schema_name.table_name",
+                "catalog_name.schema_name.table_name",
+            ),
+            (
+                "snowflake",
+                "snowflake",
+                "SELECT * FROM database_name.schema_name.table_name",
+                "database_name.schema_name.table_name",
+            ),
+            (
+                "bigquery",
+                "bigquery",
+                "SELECT * FROM `project_name.dataset_name.table_name`",
+                "project_name.dataset_name.table_name",
+            ),
+            (
+                "postgres",
+                "postgres",
+                "SELECT * FROM schema_name.table_name",
+                "schema_name.table_name",
+            ),
+            (
+                "sqlserver",
+                "tsql",
+                "SELECT * FROM [server_name].[database_name].[dbo].[orders]",
+                "server_name.database_name.orders",
+            ),
+        ],
+    )
+    def test_non_fabric_adapters_keep_existing_relation_conversion(
+        self,
+        adapter_type: str,
+        dialect: str,
+        sql: str,
+        expected: str,
+    ) -> None:
+        import sqlglot
+        from sqlglot import exp
+
+        parsed = sqlglot.parse_one(sql, dialect=dialect)
+        table = parsed.find(exp.Table)
+
+        assert table is not None
+        assert _table_to_string(table, adapter_type=adapter_type) == expected
 
 
 class TestBuildSchemaMapping:


### PR DESCRIPTION
This PR fixes two related column-lineage issues in DocGlow.

## Summary

DocGlow currently misses column lineage for qualified wildcard projections such as
`alias.*`. Fabric adapters can also use multi-part relation names, but the
current table conversion can drop relation components before resolver matching.

## Changes

- map `fabricspark` to SQLGlot's `spark` dialect
- recognize qualified wildcard expressions such as `alias.*`
- expand qualified wildcards using known output columns
- preserve full multipart relation names for Fabric adapters:
  - `fabric`
  - `fabricspark`
- keep parser dialect selection separate from relation semantics:
  - `fabric -> tsql`
  - `fabricspark -> spark`
- propagate `adapter_type` through the full lineage stack, including worker processes
- add `adapter_type` to lineage cache metadata so broken old caches are invalidated
- preserve existing relation behavior for non-Fabric adapters

## Why the Fabric handling is scoped

This does not switch relation rendering globally to `table.parts`.

Full part preservation is limited to:
- `fabric`
- `fabricspark`

Other adapters keep the existing fallback behavior to avoid silent cross-dialect
resolver changes.

## Tests

Added or updated coverage for:
- `SELECT *`
- qualified wildcards such as `SELECT t.*`
- qualified wildcard projections mixed with explicit expressions
- Fabric multipart relation handling
- non-Fabric regression cases
- cache invalidation when adapter context changes
- analyzer/shared-state propagation of adapter type

## Validation

- `uv run pytest -q tests/test_column_lineage_parallel.py tests/lineage/test_column_parser.py tests/lineage/test_analyzer.py tests/lineage/test_table_resolver.py`
- `uv run ruff check .`
- `uv run mypy src/docglow`
- real-project validation against a dbt `fabricspark` project with parallel workers

## Acceptance Criteria

- qualified wildcards like `alias.*` produce column lineage
- Fabric 2-part, 3-part, and 4-part relations resolve correctly
- `fabricspark` still parses with SQLGlot's `spark` dialect
- `fabric` still parses with SQLGlot's `tsql` dialect
- non-Fabric adapter behavior remains unchanged
- sequential and parallel lineage results remain consistent
- old caches invalidate when adapter context changes